### PR TITLE
fix: fixing Building macos app workflow

### DIFF
--- a/.github/workflows/build-appling.yaml
+++ b/.github/workflows/build-appling.yaml
@@ -213,7 +213,7 @@ jobs:
         run: |
           bare-build \
             --identifier "com.pears.pass" \
-            --target=darwin-${{ matrix.arch }} \
+            --host=darwin-${{ matrix.arch }} \
             --icon lib/icons/darwin/icon.png \
             --sign \
             --identity "$APPLE_SIGNING_IDENTITY" \

--- a/appling/README.md
+++ b/appling/README.md
@@ -45,19 +45,19 @@ npm install
 ### macOS (Apple Silicon)
 
 ```sh
-bare-build --target=darwin-arm64 --icon lib/icons/darwin/icon.png app.cjs
+bare-build --host=darwin-arm64 --icon lib/icons/darwin/icon.png app.cjs
 ```
 
 ### macOS (Intel)
 
 ```sh
-bare-build --target=darwin-x64 --icon lib/icons/darwin/icon.png app.cjs
+bare-build --host=darwin-x64 --icon lib/icons/darwin/icon.png app.cjs
 ```
 
 ### Linux
 
 ```sh
-bare-build --target=linux-x64 --icon lib/icons/linux/icon.png --package app.cjs
+bare-build --host=linux-x64 --icon lib/icons/linux/icon.png --package app.cjs
 ```
 
 ### Signed macOS Build


### PR DESCRIPTION
[Ticket ID](url)

### Requirements
- Fix macOS CI build failure from unsupported bare-build flag
- Align docs with CI build flags

### Changes
- Switched macOS bare-build flag to `--host` in `.github/workflows/build-appling.yaml`
- Updated `appling/README.md` build commands to use `--host`

### Testing Notes
- Not run locally (CI workflow change)

### Things reviewers should pay attention to
- Confirm bare-build CLI supports `--host` for macOS and Linux in CI

### Screenshots/Recordings
- N/A

### dependencies
- None
