### PR TITLE
Display Vault name accordingly everywhere

### DIFF
--- a/src/containers/Sidebar/index.js
+++ b/src/containers/Sidebar/index.js
@@ -38,6 +38,7 @@ import {
 } from '../../lib-react-components'
 import { LogoLock } from '../../svgs/LogoLock'
 import { FAVORITES_FOLDER_ID } from '../../utils/isFavorite'
+import { sortByName } from '../../utils/sortByName'
 import { AddDeviceModalContent } from '../Modal/AddDeviceModalContent'
 import { CreateFolderModalContent } from '../Modal/CreateFolderModalContent'
 
@@ -65,7 +66,7 @@ export const Sidebar = ({ sidebarSize = 'tight' }) => {
   const { data: vaultData } = useVault()
 
   const vaults = useMemo(
-    () => vaultsData?.filter((vault) => vault.id !== vaultData?.id),
+    () => sortByName(vaultsData?.filter((vault) => vault.id !== vaultData?.id)),
     [vaultsData, vaultData]
   )
 

--- a/src/pages/SettingsView/ExportTab/index.js
+++ b/src/pages/SettingsView/ExportTab/index.js
@@ -26,6 +26,7 @@ import { VaultPasswordFormModalContent } from '../../../containers/Modal/VaultPa
 import { useModal } from '../../../context/ModalContext'
 import { useTranslation } from '../../../hooks/useTranslation.js'
 import { ButtonSecondary } from '../../../lib-react-components'
+import { sortByName } from '../../../utils/sortByName'
 import { vaultCreatedFormat } from '../../../utils/vaultCreated'
 
 export const ExportTab = () => {
@@ -176,7 +177,7 @@ export const ExportTab = () => {
 
   return html` <${CardSingleSetting} title=${t('Export')}>
     <${ContentContainer}>
-      ${data?.map(
+      ${sortByName(data).map(
         (vault) =>
           html`<${ListItem}
             key=${vault.name}

--- a/src/pages/SettingsView/SettingsVaultsTab/index.js
+++ b/src/pages/SettingsView/SettingsVaultsTab/index.js
@@ -7,6 +7,7 @@ import { CardSingleSetting } from '../../../components/CardSingleSetting'
 import { ListItem } from '../../../components/ListItem'
 import { ModifyVaultModalContent } from '../../../containers/Modal/ModifyVaultModalContent'
 import { useModal } from '../../../context/ModalContext'
+import { sortByName } from '../../../utils/sortByName'
 import { vaultCreatedFormat } from '../../../utils/vaultCreated'
 
 export const SettingsVaultsTab = () => {
@@ -17,7 +18,7 @@ export const SettingsVaultsTab = () => {
   return html`
     <${CardSingleSetting} title=${i18n._('Manage Vaults')}>
       <${Content}>
-        ${data?.map(
+        ${sortByName(data).map(
           (vault) =>
             html`<${ListItem}
               key=${vault.name}

--- a/src/pages/WelcomePage/CardVaultSelect/index.js
+++ b/src/pages/WelcomePage/CardVaultSelect/index.js
@@ -20,6 +20,7 @@ import {
   ButtonSecondary,
   CommonFileIcon
 } from '../../../lib-react-components'
+import { sortByName } from '../../../utils/sortByName'
 import { vaultCreatedFormat } from '../../../utils/vaultCreated'
 
 export const CardVaultSelect = () => {
@@ -70,7 +71,7 @@ export const CardVaultSelect = () => {
 
       ${hasVaults
         ? html` <${VaultsContainer}>
-            ${data.map(
+            ${sortByName(data).map(
               (vault) =>
                 html`<${ListItem}
                   onClick=${() => handleSelectVault(vault.id)}

--- a/src/utils/sortByName.js
+++ b/src/utils/sortByName.js
@@ -1,0 +1,19 @@
+/**
+ * Sorts an array of objects alphabetically by their name property.
+ * Uses case-insensitive comparison with locale support.
+ *
+ * @template T
+ * @param {T[]} items - Array of objects with a name property
+ * @returns {T[]} New sorted array (does not mutate original)
+ *
+ **/
+
+export const sortByName = (items) => {
+  if (!items || !Array.isArray(items)) {
+    return []
+  }
+
+  return [...items].sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+  )
+}

--- a/src/utils/sortByName.test.js
+++ b/src/utils/sortByName.test.js
@@ -1,0 +1,37 @@
+import { sortByName } from './sortByName'
+
+describe('sortByName', () => {
+  it('sorts items alphabetically by name', () => {
+    const items = [{ name: 'Charlie' }, { name: 'Alpha' }, { name: 'Beta' }]
+    const result = sortByName(items)
+    expect(result.map((i) => i.name)).toEqual(['Alpha', 'Beta', 'Charlie'])
+  })
+
+  it('handles case-insensitive sorting', () => {
+    const items = [{ name: 'beta' }, { name: 'Alpha' }, { name: 'CHARLIE' }]
+    const result = sortByName(items)
+    expect(result.map((i) => i.name)).toEqual(['Alpha', 'beta', 'CHARLIE'])
+  })
+
+  it('returns empty array for null/undefined input', () => {
+    expect(sortByName(null)).toEqual([])
+    expect(sortByName(undefined)).toEqual([])
+  })
+
+  it('does not mutate original array', () => {
+    const original = [{ name: 'B' }, { name: 'A' }]
+    const result = sortByName(original)
+    expect(original[0].name).toBe('B')
+    expect(result[0].name).toBe('A')
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(sortByName([])).toEqual([])
+  })
+
+  it('handles single item array', () => {
+    const items = [{ name: 'Single' }]
+    const result = sortByName(items)
+    expect(result).toEqual([{ name: 'Single' }])
+  })
+})


### PR DESCRIPTION
### Changes
<!-- Summarize the changes introduced in this PR -->
 Implemented alphabetical sorting for vault names in all vault lists/dropdowns.
 
### Testing Notes
<!-- How did you test it? -->
Mac os Desktop app

### Screenshots/Recordings
<!-- Add screenshots or screen recordings if applicable -->

https://github.com/user-attachments/assets/0e801fee-b0b2-41a9-97d4-4e4be4ff6231

