### PR TITLE
fix: hot reload TS

### DIFF
--- a/src/hooks/usePearUpdate.js
+++ b/src/hooks/usePearUpdate.js
@@ -33,11 +33,14 @@ export const usePearUpdate = () => {
   }
 
   const onPearUpdate = (update) => {
-    if (!hasNonIgnoredChanges(update?.diff)) {
+    if (shouldIgnoreChanges(update?.diff)) {
       return
     }
 
+    // `key` is undefined in DEV mode.
     if (!Pear.config.key) {
+      // Reload is necessary for hot-reload after TS compile.
+      Pear.reload()
       return
     }
 
@@ -51,12 +54,12 @@ export const usePearUpdate = () => {
   }, [])
 }
 
-function hasNonIgnoredChanges(diff) {
-  return diff?.some(
+function shouldIgnoreChanges(diff) {
+  return diff?.every(
     ({ key: file }) =>
-      !file.startsWith('/src') &&
-      !file.startsWith('/logs') &&
-      !file.includes('pearpass-native-messaging.sock')
+      file.startsWith('/src') ||
+      file.startsWith('/logs') ||
+      file.includes('pearpass-native-messaging.sock')
   )
 }
 

--- a/src/hooks/usePearUpdate.test.js
+++ b/src/hooks/usePearUpdate.test.js
@@ -69,7 +69,7 @@ describe('usePearUpdate', () => {
 
     expect(setModalMock).not.toHaveBeenCalled()
     expect(Pear.restart).not.toHaveBeenCalled()
-    expect(Pear.reload).not.toHaveBeenCalled()
+    expect(Pear.reload).toHaveBeenCalled()
   })
 
   it('triggers restart when update handler is called', async () => {

--- a/src/pages/WelcomePage/CardUnlockPearPass/index.tsx
+++ b/src/pages/WelcomePage/CardUnlockPearPass/index.tsx
@@ -18,7 +18,6 @@ export const CardUnlockPearPass = () => {
     navigate(currentPage, { state: 'vaults' })
   }
 
-   
   const handleError = async (error: string | Error, setErrors: (errors: { password: string }) => void) => {
     const status = await refreshMasterPasswordStatus()
 


### PR DESCRIPTION
## Changes

1. Previous commits removed a critical statement required for hot reloading. I have restored Pear.reload(). After consulting with other developers regarding its initial removal, they confirmed the deletion was unintentional.

2. Added inline comments to clarify the purpose of this code section, ensuring future developers understand its necessity.

3. Refactored the conditional statement to remove the double negative, which classically impairs code readability.