### PR TITLE
Add data-id QA selectors and fix data-testid placement for end-to-end…

### DIFF
--- a/e2e/components/CreateOrEditPage.js
+++ b/e2e/components/CreateOrEditPage.js
@@ -22,7 +22,7 @@ class CreateOrEditPage {
   }
 
   get createOrEditCustomInputField() {
-    return this.root.getByTestId(`createoredit-createcustomfield`)
+    return this.root.getByTestId(`createoredit-button-createcustom`)
   }
 
   get createCustomNote() {

--- a/src/components/CreateCustomField/__snapshots__/index.test.js.snap
+++ b/src/components/CreateCustomField/__snapshots__/index.test.js.snap
@@ -7,7 +7,6 @@ exports[`CreateCustomField component renders with correct initial state 1`] = `
   >
     <div
       class="sc-hvigdm bLQxQc"
-      data-testid="createcustomfield-label-closed"
     >
       <svg
         fill="none"

--- a/src/components/CreateCustomField/index.js
+++ b/src/components/CreateCustomField/index.js
@@ -54,10 +54,11 @@ const OPTIONS = [
 /**
  * @param {{
  *  onCreateCustom: (type: string) => void,
- *  testId?: string
+ *  testId?: string,
+ *  dataId?: string
  * }} props
  */
-export const CreateCustomField = ({ onCreateCustom, testId }) => {
+export const CreateCustomField = ({ onCreateCustom, testId, dataId }) => {
   const { i18n } = useLingui()
 
   const [isOpen, setIsOpen] = useState(false)
@@ -75,11 +76,8 @@ export const CreateCustomField = ({ onCreateCustom, testId }) => {
   }
 
   return html`
-    <${Wrapper} ref=${wrapperRef} data-testid=${testId}>
-      <${Label}
-        data-testid=${`createcustomfield-label-${isOpen ? 'open' : 'closed'}`}
-        onClick=${() => setIsOpen(!isOpen)}
-      >
+    <${Wrapper} ref=${wrapperRef} data-id=${dataId}>
+      <${Label} data-testid=${testId} onClick=${() => setIsOpen(!isOpen)}>
         <${PlusIcon} size="21" />
 
         <div>${i18n._('Create Custom')}</div>

--- a/src/components/Record/index.js
+++ b/src/components/Record/index.js
@@ -35,7 +35,8 @@ import {
  *  isSelected: boolean,
  *  onClick: () => void
  *  onSelect: () => void,
- *  testId?: string
+ *  testId?: string,
+ *  dataId?: string
  * }} props
  */
 export const Record = ({
@@ -43,7 +44,8 @@ export const Record = ({
   isSelected = false,
   onClick,
   onSelect,
-  testId
+  testId,
+  dataId
 }) => {
   const [isOpen, setIsOpen] = useState()
 
@@ -71,6 +73,7 @@ export const Record = ({
       isSelected=${isSelected}
       onClick=${onClick}
       data-testid=${testId}
+      data-id=${dataId}
     >
       <${RecordInformation}>
         <${RecordAvatar}

--- a/src/components/RecordActionsPopupContent/index.js
+++ b/src/components/RecordActionsPopupContent/index.js
@@ -24,6 +24,7 @@ export const RecordActionsPopupContent = ({
       (item) => html`
         <${MenuItem}
           data-testid=${`recordaction-item-${item.type}`}
+          data-id=${item.dataId}
           key=${item.type}
           variant=${variant}
           onClick=${(e) => {

--- a/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditCreditCardModalContent/index.js
+++ b/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditCreditCardModalContent/index.js
@@ -366,7 +366,7 @@ export const CreateOrEditCreditCardModalContent = ({
 
         <${FormGroup}>
           <${CreateCustomField}
-            testId="createoredit-createcustomfield"
+            testId="createoredit-button-createcustom"
             onCreateCustom=${(type) => addItem({ type: type, name: type })}
           />
         <//>

--- a/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditCustomModalContent/index.js
+++ b/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditCustomModalContent/index.js
@@ -176,6 +176,7 @@ export const CreateOrEditCustomModalContent = ({
     <${ModalContent}
       onSubmit=${handleSubmit(onSubmit)}
       onClose=${closeModal}
+      closeButtonDataId="custom-close-button"
       headerChildren=${html`
         <${FormModalHeaderWrapper}
           buttons=${html`
@@ -188,6 +189,7 @@ export const CreateOrEditCustomModalContent = ({
             <//>
             <${ButtonLittle}
               testId="createoredit-button-save"
+              dataId="custom-save-button"
               startIcon=${SaveIcon}
               type="submit"
             >
@@ -215,6 +217,7 @@ export const CreateOrEditCustomModalContent = ({
         <${FormGroup}>
           <${InputField}
             testId="createoredit-input-title"
+            dataId="custom-title-input"
             label=${i18n._('Title')}
             placeholder=${i18n._('Insert title')}
             variant="outline"
@@ -252,15 +255,18 @@ export const CreateOrEditCustomModalContent = ({
           <//>
         `}
 
-        <${CustomFields}
-          customFields=${list}
-          register=${registerItem}
-          removeItem=${removeItem}
-        />
+        <div data-id="custom-field">
+          <${CustomFields}
+            customFields=${list}
+            register=${registerItem}
+            removeItem=${removeItem}
+          />
+        </div>
 
         <${FormGroup}>
           <${CreateCustomField}
-            testId="createoredit-button-createcustomfield"
+            testId="createoredit-button-createcustom"
+            dataId="custom-add-field-button"
             onCreateCustom=${(type) => addItem({ type: type, name: type })}
           />
         <//>

--- a/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditIdentityModalContent/index.js
+++ b/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditIdentityModalContent/index.js
@@ -684,7 +684,7 @@ export const CreateOrEditIdentityModalContent = ({
 
         <${FormGroup}>
           <${CreateCustomField}
-            testId="createoredit-createcustomfield"
+            testId="createoredit-button-createcustom"
             onCreateCustom=${(type) => addItem({ type: type, name: type })}
           />
         <//>

--- a/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditLoginModalContent/index.js
+++ b/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditLoginModalContent/index.js
@@ -400,7 +400,7 @@ export const CreateOrEditLoginModalContent = ({
 
         <${FormGroup}>
           <${CreateCustomField}
-            testId="createoredit-createcustomfield"
+            testId="createoredit-button-createcustom"
             onCreateCustom=${(type) =>
               addCustomField({ type: type, name: type })}
           />

--- a/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditNoteModalContent/index.js
+++ b/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditNoteModalContent/index.js
@@ -177,11 +177,13 @@ export const CreateOrEditNoteModalContent = ({
     <${ModalContent}
       onSubmit=${handleSubmit(onSubmit)}
       onClose=${closeModal}
+      closeButtonDataId="note-close-button"
       headerChildren=${html`
         <${FormModalHeaderWrapper}
           buttons=${html`
             <${ButtonLittle}
               testId="createoredit-button-loadfile"
+              dataId="note-load-file-button"
               startIcon=${ImageIcon}
               onClick=${handleFileLoad}
             >
@@ -189,6 +191,7 @@ export const CreateOrEditNoteModalContent = ({
             <//>
             <${ButtonLittle}
               testId="createoredit-button-save"
+              dataId="note-save-button"
               startIcon=${SaveIcon}
               type="submit"
             >
@@ -217,6 +220,7 @@ export const CreateOrEditNoteModalContent = ({
         <${FormGroup}>
           <${InputField}
             testId="createoredit-input-title"
+            dataId="note-title-input"
             label=${i18n._('Title')}
             placeholder=${i18n._('Insert title')}
             variant="outline"
@@ -227,6 +231,7 @@ export const CreateOrEditNoteModalContent = ({
         <${FormGroup}>
           <${TextArea}
             testId="createoredit-textarea-note"
+            dataId="note-content-textarea"
             ...${register('note')}
             placeholder=${i18n._('Write a note...')}
           />
@@ -270,7 +275,7 @@ export const CreateOrEditNoteModalContent = ({
 
         <${FormGroup}>
           <${CreateCustomField}
-            testId="createoredit-createcustomfield"
+            testId="createoredit-button-createcustom"
             onCreateCustom=${(type) => addItem({ type: type, name: type })}
           />
         <//>

--- a/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditWifiModalContent/index.js
+++ b/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditWifiModalContent/index.js
@@ -302,7 +302,7 @@ export const CreateOrEditWifiModalContent = ({
 
         <${FormGroup}>
           <${CreateCustomField}
-            testId="createoredit-createcustomfield"
+            testId="createoredit-button-createcustom"
             onCreateCustom=${(type) => addItem({ type: type, name: type })}
           />
         <//>

--- a/src/containers/Modal/ModalContent/index.js
+++ b/src/containers/Modal/ModalContent/index.js
@@ -12,6 +12,7 @@ import { ModalHeader } from '../ModalHeader'
  *  showCloseButton?: boolean
  *  borderColor?: string
  *  borderRadius?: string
+ *  closeButtonDataId?: string
  * }} props
  */
 export const ModalContent = ({
@@ -21,7 +22,8 @@ export const ModalContent = ({
   children,
   showCloseButton = true,
   borderColor,
-  borderRadius
+  borderRadius,
+  closeButtonDataId
 }) => html`
   <${Wrapper} $borderColor=${borderColor} $borderRadius=${borderRadius}>
     <${onSubmit ? 'form' : 'div'}
@@ -30,7 +32,11 @@ export const ModalContent = ({
         onSubmit?.()
       }}
     >
-      <${ModalHeader} onClose=${onClose} showCloseButton=${showCloseButton}>
+      <${ModalHeader}
+        onClose=${onClose}
+        showCloseButton=${showCloseButton}
+        closeButtonDataId=${closeButtonDataId}
+      >
         ${headerChildren}
       <//>
 

--- a/src/containers/Modal/ModalHeader/index.js
+++ b/src/containers/Modal/ModalHeader/index.js
@@ -8,12 +8,14 @@ import { ButtonRoundIcon, XIcon } from '../../../lib-react-components'
  *  onClose: () => void
  *  children: import('react').ReactNode
  *  showCloseButton?: boolean
+ *  closeButtonDataId?: string
  * }} props
  */
 export const ModalHeader = ({
   onClose,
   children,
-  showCloseButton = true
+  showCloseButton = true,
+  closeButtonDataId
 }) => html`
   <${Header}>
     <${HeaderChildrenWrapper}> ${children} <//>
@@ -22,7 +24,8 @@ export const ModalHeader = ({
     html`<${ButtonRoundIcon}
       onClick=${onClose}
       startIcon=${XIcon}
-      data-testid="modalheader-button-close"
+      testId="modalheader-button-close"
+      dataId=${closeButtonDataId}
     />`}
   <//>
 `

--- a/src/containers/PassPhrase/index.js
+++ b/src/containers/PassPhrase/index.js
@@ -117,7 +117,7 @@ export const PassPhrase = ({
         <${PassPhraseIcon} />
         <${HeaderText}>${t('Recovery phrase 2')}<//>
       <//>
-      <${PassPhraseContainer}>
+      <${PassPhraseContainer} data-testid="passphrase-words-container">
         ${passphraseWords.map(
           (word, i) =>
             html`<${BadgeTextItem}

--- a/src/containers/RecordDetails/CustomDetailsForm/index.js
+++ b/src/containers/RecordDetails/CustomDetailsForm/index.js
@@ -57,7 +57,7 @@ export const CustomDetailsForm = ({ initialRecord, selectedFolder }) => {
   }, [initialValues, setValues])
 
   return html`
-    <${FormWrapper}>
+    <${FormWrapper} data-id="custom-details">
       <${CustomFields}
         areInputsDisabled=${true}
         customFields=${list}

--- a/src/containers/RecordDetails/NoteDetailsForm/index.js
+++ b/src/containers/RecordDetails/NoteDetailsForm/index.js
@@ -59,7 +59,7 @@ export const NoteDetailsForm = ({ initialRecord, selectedFolder }) => {
   }, [initialValues, setValues])
 
   return html`
-    <${FormWrapper}>
+    <${FormWrapper} data-id="note-details">
       <${FormGroup}>
         ${!!values?.note?.length &&
         html`

--- a/src/containers/RecordDetails/PassPhraseDetailsForm/index.js
+++ b/src/containers/RecordDetails/PassPhraseDetailsForm/index.js
@@ -49,7 +49,7 @@ export const PassPhraseDetailsForm = ({ initialRecord, selectedFolder }) => {
   }, [initialValues, setValues])
 
   return html`
-    <${FormWrapper}>
+    <${FormWrapper} data-testid="recoveryphrase-details">
       <${FormGroup}>
         ${!!values?.passPhrase?.length &&
         html`<${PassPhrase} ...${register('passPhrase')} /> `}

--- a/src/containers/RecordDetails/index.js
+++ b/src/containers/RecordDetails/index.js
@@ -48,13 +48,28 @@ export const RecordDetails = () => {
   const { handleCreateOrEditRecord } = useCreateOrEditRecord()
   const { updateFavoriteState } = useRecords()
 
-  const { actions } = useRecordActionItems({
+  const DATA_ID_PREFIX_BY_TYPE = {
+    note: 'note',
+    custom: 'custom'
+  }
+
+  const dataIdPrefix = DATA_ID_PREFIX_BY_TYPE[record?.type]
+
+  const { actions: rawActions } = useRecordActionItems({
     excludeTypes: ['select', 'pin'],
     record: record,
     onClose: () => {
       setIsOpen(false)
     }
   })
+
+  const actions = dataIdPrefix
+    ? rawActions.map((action) =>
+        action.type === 'delete'
+          ? { ...action, dataId: `${dataIdPrefix}-delete-button` }
+          : action
+      )
+    : rawActions
 
   const handleEdit = () => {
     handleCreateOrEditRecord({
@@ -122,7 +137,8 @@ export const RecordDetails = () => {
           <//>
 
           <${ButtonLittle}
-            data-testid="details-button-edit"
+            testId="details-button-edit"
+            dataId=${dataIdPrefix ? `${dataIdPrefix}-edit-button` : undefined}
             startIcon=${BrushIcon}
             onClick=${handleEdit}
           >

--- a/src/containers/RecordListView/index.js
+++ b/src/containers/RecordListView/index.js
@@ -243,6 +243,11 @@ export const RecordListView = ({
 
               <${Record}
                 testId="recordList-record-container"
+                dataId=${record.type === 'note'
+                  ? 'note-list-item'
+                  : record.type === 'custom'
+                    ? 'custom-list-item'
+                    : undefined}
                 record=${record}
                 isSelected=${isSelected}
                 onSelect=${() => handleSelect(record, isSelected)}

--- a/src/lib-react-components/components/ButtonLittle/index.js
+++ b/src/lib-react-components/components/ButtonLittle/index.js
@@ -9,7 +9,8 @@ import { Button } from './styles'
  *  startIcon?: import('react').ElementType
  *  type?: 'button' | 'submit'
  *  onClick: () => void,
- *  testId?: string
+ *  testId?: string,
+ *  dataId?: string
  * }} props
  */
 export const ButtonLittle = ({
@@ -18,10 +19,12 @@ export const ButtonLittle = ({
   variant = 'primary',
   type = 'button',
   onClick,
-  testId
+  testId,
+  dataId
 }) => html`
   <${Button}
     data-testid=${testId}
+    data-id=${dataId}
     type=${type}
     variant=${variant}
     onClick=${onClick}

--- a/src/lib-react-components/components/ButtonRoundIcon/index.js
+++ b/src/lib-react-components/components/ButtonRoundIcon/index.js
@@ -9,7 +9,8 @@ import { Button } from './styles'
  *  startIcon: import('react').ElementType
  *  onClick: () => void
  *  iconSize?: string,
- *  testId?: string
+ *  testId?: string,
+ *  dataId?: string
  * }} props
  */
 export const ButtonRoundIcon = ({
@@ -17,9 +18,15 @@ export const ButtonRoundIcon = ({
   startIcon,
   onClick,
   iconSize,
-  testId = 'button-round-icon'
+  testId = 'button-round-icon',
+  dataId
 }) => html`
-  <${Button} type="button" onClick=${onClick} data-testid=${testId}>
+  <${Button}
+    type="button"
+    onClick=${onClick}
+    data-testid=${testId}
+    data-id=${dataId}
+  >
     ${startIcon &&
     html`<${startIcon}
       color=${colors.primary400.mode1}

--- a/src/lib-react-components/components/InputField/index.tsx
+++ b/src/lib-react-components/components/InputField/index.tsx
@@ -34,6 +34,7 @@ interface Props {
   overlay?: React.ReactNode
   autoFocus?: boolean
   testId?: string
+  dataId?: string
   onPaste?: (e: React.ClipboardEvent<HTMLInputElement>) => void
 }
 
@@ -54,6 +55,7 @@ const InputField = (props: Props): React.ReactElement => {
     overlay,
     autoFocus,
     testId = 'input-field',
+    dataId,
     onPaste
   } = props
 
@@ -100,6 +102,7 @@ const InputField = (props: Props): React.ReactElement => {
           <InputAreaWrapper>
             <Input
               data-testid={testId}
+              data-id={dataId}
               ref={inputRef}
               value={value}
               onChange={handleChange}

--- a/src/lib-react-components/components/TextArea/__snapshots__/index.test.js.snap
+++ b/src/lib-react-components/components/TextArea/__snapshots__/index.test.js.snap
@@ -3,13 +3,13 @@
 exports[`TextArea Component matches snapshot for default variant 1`] = `
 <div
   class="sc-fhHczv eLkUHf"
-  data-testid="text-area"
 >
   <div
     class="sc-ggWZvA evJOyk"
   >
     <textarea
       class="sc-bRKDuR cVKynm"
+      data-testid="text-area"
       placeholder="Enter text here"
     >
       snapshot default
@@ -21,13 +21,13 @@ exports[`TextArea Component matches snapshot for default variant 1`] = `
 exports[`TextArea Component matches snapshot for report variant 1`] = `
 <div
   class="sc-fhHczv eLkUHf"
-  data-testid="text-area"
 >
   <div
     class="sc-ggWZvA evJOyk"
   >
     <textarea
       class="sc-hvigdm juBlam"
+      data-testid="text-area"
       placeholder="Report here"
     >
       snapshot report

--- a/src/lib-react-components/components/TextArea/index.tsx
+++ b/src/lib-react-components/components/TextArea/index.tsx
@@ -19,6 +19,7 @@ interface Props {
   onClick?: (value: string) => void
   variant?: Variant
   testId?: string
+  dataId?: string
   additionalItems?: React.ReactNode
 }
 
@@ -30,6 +31,7 @@ export const TextArea = ({
   onClick,
   variant = 'default',
   testId = 'text-area',
+  dataId,
   additionalItems
 }: Props) => {
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -49,9 +51,10 @@ export const TextArea = ({
   const TextAreaEl = variant === 'report' ? ReportTextAreaComponent : TextAreaComponent
 
   return html`
-    <${Wrapper} data-testid=${testId} onClick=${handleClick}>
+    <${Wrapper} data-id=${dataId} onClick=${handleClick}>
       <${TextAreaWrapper}>
         <${TextAreaEl}
+          data-testid=${testId}
           value=${value}
           onChange=${handleChange}
           placeholder=${placeholder}

--- a/src/pages/SettingsView/SettingsTab/SettingsReportSection/__snapshots__/index.test.js.snap
+++ b/src/pages/SettingsView/SettingsTab/SettingsReportSection/__snapshots__/index.test.js.snap
@@ -20,13 +20,13 @@ exports[`SettingsReportSection matches snapshot 1`] = `
       >
         <div
           class="sc-jytpVa dLDlNu"
-          data-testid="text-area"
         >
           <div
             class="sc-eknHtZ gUwSmg"
           >
             <textarea
               class="sc-cdmAjP kJVkCe"
+              data-testid="text-area"
               placeholder="Describe the issue"
             />
           </div>


### PR DESCRIPTION
… automation.

### Changes

Add persistent data-id attributes to Note and Custom item flows for stable automation, replacing brittle text/content selectors.                                                                                                               
  

-   Note: note-title-input, note-content-textarea, note-save-button, note-load-file-button, note-close-button, note-list-item, note-details, note-edit-button, note-delete-button.

-   Custom: custom-title-input, custom-field, custom-add-field-button, custom-save-button, custom-close-button, custom-list-item, custom-details, custom-edit-button, custom-delete-button.

Fix data-testid issues:
  - Move CreateCustomField testId from wrapper div to clickable label and
    standardize naming to "createoredit-button-createcustom" across all
    six create/edit modals
  - Move TextArea testId from wrapper div to <textarea> element
  - Add data-testid="passphrase-words-container" to Recovery Phrase word
    grid for reliable targeting
  - Add data-testid="recoveryphrase-details" to Recovery Phrase details
    view container

Update affected snapshots and E2E page object selectors.

### Screenshots/Recordings

- 

https://github.com/user-attachments/assets/9d5cf93e-b14f-4dfb-9123-19dfc8d82951



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213112191156973
  - https://app.asana.com/0/0/1213112191156965