### PR TITLE
Removed the description from report a problem

### DIFF
--- a/src/pages/SettingsView/AboutContent/index.js
+++ b/src/pages/SettingsView/AboutContent/index.js
@@ -95,9 +95,6 @@ export const AboutContent = () => {
       onSubmitReport=${handleReportProblem}
       message=${message}
       title=${i18n._('Report a problem')}
-      description=${i18n._(
-        "Tell us what's going wrong and leave your email so we can follow up with you."
-      )}
       buttonText=${i18n._('send')}
       textAreaPlaceholder=${i18n._('Write your issue...')}
       textAreaOnChange=${setMessage}


### PR DESCRIPTION
### Requirements

we currently don't have the capability to add your email when reporting a problem (just the current simple text) so the description should have not been updated. 

### Changes

Removed the description from report a problem

