### PR TITLE
Ensures the installer process terminates after launching the app.

### DIFF
--- a/appling/lib/install.cjs
+++ b/appling/lib/install.cjs
@@ -49,6 +49,7 @@ async function install(id, opts = {}) {
         const appInstance = new appling.App(id);
         appInstance.open();
         window.close();
+        Bare.exit();
         break;
       }
     }


### PR DESCRIPTION
### Changes

- Added Bare.exit() after window.close() in the "launch" handler. This ensures the installer process terminates after launching the app, matching the behavior during the preflight check when the app is already installed.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212822036845837