### PR TITLE
Close pairing modal after time expires

### DIFF
--- a/src/containers/Modal/AddDeviceModalContent/ScanQRExpireTimer.tsx
+++ b/src/containers/Modal/AddDeviceModalContent/ScanQRExpireTimer.tsx
@@ -4,12 +4,15 @@ import { useCountDown } from 'pear-apps-lib-ui-react-hooks'
 
 import { ExpireTime } from './styles'
 
-export const ScanQRExpireTimer = () => {
+interface Props {
+  onFinish?: () => void
+}
+
+export const ScanQRExpireTimer = ({ onFinish }: Props) => {
   const expireTime = useCountDown({
     initialSeconds: 120,
+    onFinish
   })
 
   return html`<${ExpireTime}> ${expireTime} <//>`
 }
-
-

--- a/src/containers/Modal/AddDeviceModalContent/index.ts
+++ b/src/containers/Modal/AddDeviceModalContent/index.ts
@@ -232,7 +232,7 @@ export const AddDeviceModalContent = () => {
               <${BackgroundSection}>
                 <${ExpireText}>
                   ${t('Expires in')}
-                  <${ScanQRExpireTimer} />
+                  <${ScanQRExpireTimer} onFinish=${closeModal} />
                 <//>
 
                 <${TimeIcon} color=${colors.primary400.mode1} />


### PR DESCRIPTION
### Requirements
<!-- List the requirements for this PR -->
Pairing modal should close after pairing link expires.

### Changes
<!-- Summarize the changes introduced in this PR -->
Add onFinish prop for timer.

### Testing Notes
<!-- How did you test it? -->

### Things reviewers should pay attention to
<!-- Highlight anything specific you want reviewers to focus on -->

### Screenshots/Recordings
<!-- Add screenshots or screen recordings if applicable -->

https://github.com/user-attachments/assets/6725b038-453d-463e-9cb5-e710fa039580



### dependencies
<!-- List any dependent work items or PRs -->
