### PR TITLE
Stable socket path (#173)

### DIFF
--- a/src/services/ipc/SocketManager.js
+++ b/src/services/ipc/SocketManager.js
@@ -1,10 +1,13 @@
 import fs from 'fs'
-import { platform, tmpdir } from 'os'
+import { platform } from 'os'
 import { join } from 'path'
 
 import { logger } from '../../utils/logger'
 
 const { unlink } = fs.promises
+
+const SOCKET_DIR_NAME = 'pearpass'
+const getSocketDir = () => join(Pear.config.pearDir, SOCKET_DIR_NAME)
 
 /**
  * Manages IPC socket creation and cleanup
@@ -22,7 +25,8 @@ export class SocketManager {
     if (platform() === 'win32') {
       return `\\\\?\\pipe\\${socketName}`
     }
-    return join(tmpdir(), `${socketName}.sock`)
+
+    return join(getSocketDir(), `${socketName}.sock`)
   }
 
   /**
@@ -42,6 +46,14 @@ export class SocketManager {
         )
       }
     }
+  }
+
+  /**
+   * Ensure the socket directory exists
+   */
+  async ensureSocketDir() {
+    if (platform() === 'win32') return
+    await fs.promises.mkdir(getSocketDir(), { recursive: true })
   }
 
   /**

--- a/src/services/ipc/SocketManager.test.js
+++ b/src/services/ipc/SocketManager.test.js
@@ -14,6 +14,12 @@ jest.mock('../../utils/logger', () => ({
   }
 }))
 
+global.Pear = {
+  config: {
+    pearDir: '/tmp'
+  }
+}
+
 import fs from 'fs'
 
 import { SocketManager, getIpcPath } from './SocketManager'
@@ -22,7 +28,7 @@ const { logger } = require('../../utils/logger')
 
 describe('SocketManager', () => {
   const socketName = 'testSocket'
-  const unixPath = '/tmp/testSocket.sock'
+  const unixPath = '/tmp/pearpass/testSocket.sock'
   const winPath = '\\\\?\\pipe\\testSocket'
 
   beforeEach(() => {
@@ -105,6 +111,6 @@ describe('getIpcPath', () => {
   it('returns socket path for given name', () => {
     require('os').platform.mockReturnValue('linux')
     require('os').tmpdir.mockReturnValue('/tmp')
-    expect(getIpcPath('foo')).toBe('/tmp/foo.sock')
+    expect(getIpcPath('foo')).toBe('/tmp/pearpass/foo.sock')
   })
 })

--- a/src/services/nativeMessagingIPCServer.test.js
+++ b/src/services/nativeMessagingIPCServer.test.js
@@ -20,10 +20,11 @@ jest.mock('os', () => ({
   tmpdir: jest.fn(() => '/tmp')
 }))
 
-// Mock Pear.config.storage
+// Mock Pear.config.storage and pearDir (used by SocketManager for socket paths)
 global.Pear = {
   config: {
-    storage: '/mock/pear/storage'
+    storage: '/mock/pear/storage',
+    pearDir: '/tmp'
   }
 }
 
@@ -210,7 +211,9 @@ describe('nativeMessagingIPCServer', () => {
     it('should return a unix domain socket path on non-win32 platforms', () => {
       platform.mockReturnValue('linux')
       const socketName = 'test-socket'
-      expect(getIpcPath(socketName)).toBe(join('/tmp', `${socketName}.sock`))
+      expect(getIpcPath(socketName)).toBe(
+        join('/tmp', 'pearpass', `${socketName}.sock`)
+      )
     })
   })
 
@@ -227,7 +230,7 @@ describe('nativeMessagingIPCServer', () => {
       expect(serverInstance.server).toBeNull()
       expect(serverInstance.isRunning).toBe(false)
       expect(serverInstance.socketPath).toBe(
-        join('/tmp', 'pearpass-native-messaging.sock')
+        join('/tmp', 'pearpass', 'pearpass-native-messaging.sock')
       )
     })
 
@@ -450,7 +453,7 @@ describe('nativeMessagingIPCServer', () => {
     it('getIPCSocketPath should return a default path when not running', () => {
       platform.mockReturnValue('linux')
       expect(getIPCSocketPath()).toBe(
-        join('/tmp', 'pearpass-native-messaging.sock')
+        join('/tmp', 'pearpass', 'pearpass-native-messaging.sock')
       )
     })
   })

--- a/src/utils/nativeMessagingSetup.js
+++ b/src/utils/nativeMessagingSetup.js
@@ -5,11 +5,14 @@ import path from 'path'
 
 import {
   MANIFEST_NAME,
-  NATIVE_MESSAGING_BRIDGE_PEAR_LINK_PRODUCTION,
+  // NATIVE_MESSAGING_BRIDGE_PEAR_LINK_PRODUCTION,
   EXTENSION_ID
 } from 'pearpass-lib-constants'
 
 import { logger } from './logger'
+
+export const NATIVE_MESSAGING_BRIDGE_PEAR_LINK_TEMPORARY =
+  'pear://fmsw9ndr1imn9m6zpq1rq5nwhxfi6dp6oz5k45o1dm3zrp3hwgzy'
 
 const promisify =
   (fn) =>
@@ -80,7 +83,7 @@ export const generateNativeHostExecutable = async (executablePath) => {
 # Launches the native host using pear run
 
 cd "${bridgePath}"
-exec "${pearPath}" run --trusted ${NATIVE_MESSAGING_BRIDGE_PEAR_LINK_PRODUCTION}
+exec "${pearPath}" run --trusted ${NATIVE_MESSAGING_BRIDGE_PEAR_LINK_TEMPORARY}
 `
     } else if (platform === 'linux') {
       const pearPath = path.join(
@@ -98,7 +101,7 @@ exec "${pearPath}" run --trusted ${NATIVE_MESSAGING_BRIDGE_PEAR_LINK_PRODUCTION}
 # Launches the native host using pear run
 
 cd "${bridgePath}"
-exec "${pearPath}" run --trusted ${NATIVE_MESSAGING_BRIDGE_PEAR_LINK_PRODUCTION}
+exec "${pearPath}" run --trusted ${NATIVE_MESSAGING_BRIDGE_PEAR_LINK_TEMPORARY}
 `
     } else if (platform === 'win32') {
       const pearPath = path.join(
@@ -117,7 +120,7 @@ REM PearPass Native Messaging Host for Windows
 REM Launches the native host using pear run
 
 cd /d "${bridgePath}"
-"${pearPath}" run --trusted ${NATIVE_MESSAGING_BRIDGE_PEAR_LINK_PRODUCTION}
+"${pearPath}" run --trusted ${NATIVE_MESSAGING_BRIDGE_PEAR_LINK_TEMPORARY}
 `
     } else {
       throw new Error(`Unsupported platform: ${platform}`)
@@ -433,7 +436,7 @@ export const killNativeMessagingHostProcesses = async () => {
       // The parent cmd.exe (spawned by Chrome) will automatically terminate when its child is killed
       try {
         // Use PowerShell to find processes with the unique bridge seed in their command line
-        const psCmd = `powershell -NoProfile -Command "Get-WmiObject Win32_Process | Where-Object {\$_.CommandLine -like '*${NATIVE_MESSAGING_BRIDGE_PEAR_LINK_PRODUCTION}*'} | ForEach-Object { taskkill /PID \$_.ProcessId /F }"`
+        const psCmd = `powershell -NoProfile -Command "Get-WmiObject Win32_Process | Where-Object {\$_.CommandLine -like '*${NATIVE_MESSAGING_BRIDGE_PEAR_LINK_TEMPORARY}*'} | ForEach-Object { taskkill /PID \$_.ProcessId /F }"`
         await execAsync(psCmd)
         logger.info(
           'NATIVE-MESSAGING-KILL',
@@ -450,7 +453,7 @@ export const killNativeMessagingHostProcesses = async () => {
       // The wrapper script uses 'exec' so the process name becomes 'pear run <seed>'
       try {
         await execAsync(
-          `pkill -f "${NATIVE_MESSAGING_BRIDGE_PEAR_LINK_PRODUCTION}"`
+          `pkill -f "${NATIVE_MESSAGING_BRIDGE_PEAR_LINK_TEMPORARY}"`
         )
         logger.info(
           'NATIVE-MESSAGING-KILL',

--- a/src/utils/nativeMessagingSetup.test.js
+++ b/src/utils/nativeMessagingSetup.test.js
@@ -3,8 +3,8 @@ import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
 
-import { NATIVE_MESSAGING_BRIDGE_PEAR_LINK_PRODUCTION } from 'pearpass-lib-constants'
-
+// import { NATIVE_MESSAGING_BRIDGE_PEAR_LINK_PRODUCTION } from 'pearpass-lib-constants'
+import { NATIVE_MESSAGING_BRIDGE_PEAR_LINK_TEMPORARY } from './nativeMessagingSetup'
 import {
   setupNativeMessaging,
   getNativeHostExecutableInfo,
@@ -276,7 +276,7 @@ describe('killNativeMessagingHostProcesses', () => {
     expect(execMock).toHaveBeenCalledTimes(1)
     const cmd = execMock.mock.calls[0][0]
     expect(cmd).toContain('pkill -f')
-    expect(cmd).toContain(NATIVE_MESSAGING_BRIDGE_PEAR_LINK_PRODUCTION)
+    expect(cmd).toContain(NATIVE_MESSAGING_BRIDGE_PEAR_LINK_TEMPORARY)
   })
 
   it('should kill processes on macOS', async () => {


### PR DESCRIPTION
* Change IPC socket path to pear config to prevent sandboxed environments from using different paths, add guard for concurrent IPC server starts.

* Update IPC socket paths and native messaging bridge link

---------

### dependencies
https://github.com/tetherto/pearpass-app-desktop/pull/173