### PR TITLE
Added cleanup mechanism to electron

### DIFF
--- a/electron/clipboardCleanup.cjs
+++ b/electron/clipboardCleanup.cjs
@@ -1,0 +1,148 @@
+const crypto = require('crypto')
+const fs = require('fs')
+const path = require('path')
+const { spawn } = require('child_process')
+
+const DEFAULT_CLIPBOARD_CLEAR_DELAY_MS = 30000
+const CLIPBOARD_CLEANUP_STATE_FILE = 'pearpass-clipboard-cleanup-current.token'
+
+function getClipboardCleanupStatePath(app) {
+  return path.join(app.getPath('temp'), CLIPBOARD_CLEANUP_STATE_FILE)
+}
+
+function removeFileIfExists(filePath) {
+  try {
+    fs.unlinkSync(filePath)
+  } catch (err) {
+    if (err && err.code !== 'ENOENT') throw err
+  }
+}
+
+function removeClipboardCleanupTokenIfCurrent(statePath, token) {
+  try {
+    const currentToken = fs.readFileSync(statePath, 'utf8')
+    if (currentToken === token) {
+      removeFileIfExists(statePath)
+    }
+  } catch (err) {
+    if (err && err.code !== 'ENOENT') throw err
+  }
+}
+
+function spawnDetachedClipboardHelper(secretPath, token, statePath, delayMs) {
+  const helperPath = path.join(__dirname, 'clipboardCleanupHelper.cjs')
+  if (!fs.existsSync(helperPath)) {
+    throw new Error(`Clipboard cleanup helper not found: ${helperPath}`)
+  }
+
+  const child = spawn(
+    process.execPath,
+    [helperPath, secretPath, token, statePath, String(delayMs)],
+    {
+      detached: true,
+      env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+      stdio: 'ignore',
+      windowsHide: true
+    }
+  )
+
+  child.unref()
+}
+
+function spawnDetachedWindowsClipboardHelper(
+  secretPath,
+  token,
+  statePath,
+  delayMs
+) {
+  const scriptPath = path.join(__dirname, 'clipboardCleanup.windows.ps1')
+  if (!fs.existsSync(scriptPath)) {
+    throw new Error(`Windows clipboard cleanup script not found: ${scriptPath}`)
+  }
+
+  const child = spawn(
+    'cmd.exe',
+    [
+      '/c',
+      'start',
+      '""',
+      '/min',
+      'powershell.exe',
+      '-NoProfile',
+      '-WindowStyle',
+      'Hidden',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      scriptPath,
+      '-SecretPath',
+      secretPath,
+      '-StatePath',
+      statePath,
+      '-Token',
+      token,
+      '-DelayMs',
+      String(delayMs)
+    ],
+    {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true
+    }
+  )
+
+  child.unref()
+}
+
+function scheduleClipboardCleanup({ app, clipboard, logger, isWindows, text, delayMs }) {
+  const finalDelayMs =
+    Number.isFinite(delayMs) && delayMs > 0
+      ? delayMs
+      : DEFAULT_CLIPBOARD_CLEAR_DELAY_MS
+  const textToMatch = typeof text === 'string' ? text : clipboard.readText()
+
+  if (typeof textToMatch !== 'string' || textToMatch.length === 0) {
+    return false
+  }
+
+  const token = crypto.randomUUID()
+  const statePath = getClipboardCleanupStatePath(app)
+  const secretPath = path.join(
+    app.getPath('temp'),
+    `pearpass-clipboard-secret-${token}.txt`
+  )
+
+  try {
+    fs.writeFileSync(secretPath, textToMatch, { encoding: 'utf8', mode: 0o600 })
+    fs.writeFileSync(statePath, token, { encoding: 'utf8', mode: 0o600 })
+
+    if (isWindows) {
+      spawnDetachedWindowsClipboardHelper(
+        secretPath,
+        token,
+        statePath,
+        finalDelayMs
+      )
+    } else {
+      spawnDetachedClipboardHelper(secretPath, token, statePath, finalDelayMs)
+    }
+
+    return true
+  } catch (err) {
+    try {
+      removeFileIfExists(secretPath)
+      removeClipboardCleanupTokenIfCurrent(statePath, token)
+    } catch (_) {}
+
+    logger.warn(
+      'MAIN',
+      'Failed to schedule detached clipboard cleanup:',
+      err && err.message ? err.message : err
+    )
+    return false
+  }
+}
+
+module.exports = {
+  scheduleClipboardCleanup
+}

--- a/electron/clipboardCleanup.test.js
+++ b/electron/clipboardCleanup.test.js
@@ -1,0 +1,82 @@
+/* eslint-env jest */
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn(() => true),
+  readFileSync: jest.fn(),
+  unlinkSync: jest.fn(),
+  writeFileSync: jest.fn()
+}))
+
+jest.mock('crypto', () => ({
+  randomUUID: jest.fn(() => 'token-1')
+}))
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn(() => ({
+    unref: jest.fn()
+  }))
+}))
+
+describe('clipboardCleanup', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('uses the Windows script', () => {
+    const path = require('path')
+    const fs = require('fs')
+    const { spawn } = require('child_process')
+    const { scheduleClipboardCleanup } = require('./clipboardCleanup.cjs')
+
+    const app = {
+      getPath: jest.fn((name) =>
+        name === 'temp' ? 'C:\\Temp' : `/unknown/${name}`
+      )
+    }
+    const clipboard = {
+      readText: jest.fn(() => 'secret')
+    }
+    const logger = {
+      warn: jest.fn()
+    }
+
+    const result = scheduleClipboardCleanup({
+      app,
+      clipboard,
+      logger,
+      isWindows: true,
+      text: 'secret',
+      delayMs: 30000
+    })
+
+    expect(result).toBe(true)
+    expect(fs.writeFileSync).toHaveBeenNthCalledWith(
+      1,
+      path.join('C:\\Temp', 'pearpass-clipboard-secret-token-1.txt'),
+      'secret',
+      { encoding: 'utf8', mode: 0o600 }
+    )
+    expect(fs.writeFileSync).toHaveBeenNthCalledWith(
+      2,
+      path.join('C:\\Temp', 'pearpass-clipboard-cleanup-current.token'),
+      'token-1',
+      { encoding: 'utf8', mode: 0o600 }
+    )
+    expect(spawn).toHaveBeenCalledWith(
+      'cmd.exe',
+      expect.arrayContaining([
+        '-File',
+        path.join(
+          process.cwd(),
+          'electron',
+          'clipboardCleanup.windows.ps1'
+        )
+      ]),
+      expect.objectContaining({
+        detached: true,
+        stdio: 'ignore',
+        windowsHide: true
+      })
+    )
+  })
+})

--- a/electron/clipboardCleanup.windows.ps1
+++ b/electron/clipboardCleanup.windows.ps1
@@ -1,0 +1,61 @@
+param(
+  [string]$SecretPath,
+  [string]$StatePath,
+  [string]$Token,
+  [int]$DelayMs
+)
+
+try {
+  $expected = ''
+
+  try {
+    if (-not (Test-Path -LiteralPath $SecretPath)) {
+      exit 0
+    }
+
+    $expected = [System.IO.File]::ReadAllText($SecretPath, [System.Text.Encoding]::UTF8)
+  } finally {
+    Remove-Item -LiteralPath $SecretPath -Force -ErrorAction SilentlyContinue
+  }
+
+  Start-Sleep -Milliseconds $DelayMs
+
+  $currentToken = ''
+  try {
+    if (Test-Path -LiteralPath $StatePath) {
+      $currentToken = [System.IO.File]::ReadAllText($StatePath, [System.Text.Encoding]::UTF8)
+    }
+  } catch {
+    $currentToken = ''
+  }
+
+  if (-not [string]::Equals($currentToken, $Token, [System.StringComparison]::Ordinal)) {
+    exit 0
+  }
+
+  $clipboardText = ''
+  try {
+    $clipboardText = Get-Clipboard -Raw
+  } catch {
+    $clipboardText = ''
+  }
+
+  if ([string]::Equals($clipboardText, $expected, [System.StringComparison]::Ordinal)) {
+    Set-Clipboard -Value ''
+  }
+
+  $latestToken = ''
+  try {
+    if (Test-Path -LiteralPath $StatePath) {
+      $latestToken = [System.IO.File]::ReadAllText($StatePath, [System.Text.Encoding]::UTF8)
+    }
+  } catch {
+    $latestToken = ''
+  }
+
+  if ([string]::Equals($latestToken, $Token, [System.StringComparison]::Ordinal)) {
+    Remove-Item -LiteralPath $StatePath -Force -ErrorAction SilentlyContinue
+  }
+} catch {
+  exit 1
+}

--- a/electron/clipboardCleanupHelper.cjs
+++ b/electron/clipboardCleanupHelper.cjs
@@ -1,0 +1,180 @@
+const fs = require('fs')
+const { spawnSync } = require('child_process')
+
+function removeFileIfExists(filePath) {
+  try {
+    fs.unlinkSync(filePath)
+  } catch (err) {
+    if (err && err.code !== 'ENOENT') throw err
+  }
+}
+
+function readSecretFromFile(secretPath) {
+  try {
+    return fs.readFileSync(secretPath, 'utf8')
+  } finally {
+    removeFileIfExists(secretPath)
+  }
+}
+
+function readCurrentToken(statePath) {
+  try {
+    return fs.readFileSync(statePath, 'utf8')
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return ''
+    throw err
+  }
+}
+
+function clearCurrentTokenIfMatches(statePath, token) {
+  if (readCurrentToken(statePath) === token) {
+    removeFileIfExists(statePath)
+  }
+}
+
+function logLinuxClipboardSkip() {
+  process.stderr.write(
+    'PearPass clipboard cleanup skipped: Linux clipboard command unavailable or failed.\n'
+  )
+}
+
+function sleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs))
+}
+
+function runClipboardCommand(command, args, input) {
+  return spawnSync(command, args, {
+    encoding: 'utf8',
+    input,
+    stdio: ['pipe', 'pipe', 'pipe']
+  })
+}
+
+function readClipboard() {
+  if (process.platform === 'darwin') {
+    const result = runClipboardCommand('/usr/bin/pbpaste', [], undefined)
+    if (result.error || result.status !== 0) {
+      throw result.error || new Error('pbpaste failed')
+    }
+    return result.stdout || ''
+  }
+
+  if (process.platform === 'linux') {
+    const commands = [
+      ['xsel', ['--clipboard', '--output']],
+      ['xclip', ['-selection', 'clipboard', '-o']]
+    ]
+
+    for (const [command, args] of commands) {
+      const result = runClipboardCommand(command, args, undefined)
+      if (!result.error && result.status === 0) {
+        return result.stdout || ''
+      }
+    }
+
+    logLinuxClipboardSkip()
+    return null
+  }
+
+  throw new Error(`Unsupported platform: ${process.platform}`)
+}
+
+function clearClipboard() {
+  if (process.platform === 'darwin') {
+    const result = runClipboardCommand('/usr/bin/pbcopy', [], '')
+    if (result.error || result.status !== 0) {
+      throw result.error || new Error('pbcopy failed')
+    }
+    return
+  }
+
+  if (process.platform === 'linux') {
+    const commands = [
+      ['xsel', ['--clipboard', '--input']],
+      ['xclip', ['-selection', 'clipboard']]
+    ]
+
+    for (const [command, args] of commands) {
+      const result = runClipboardCommand(command, args, '')
+      if (!result.error && result.status === 0) {
+        return
+      }
+    }
+
+    logLinuxClipboardSkip()
+    return
+  }
+
+  throw new Error(`Unsupported platform: ${process.platform}`)
+}
+
+async function runClipboardCleanup({
+  secretPath,
+  token,
+  statePath,
+  delayMs = 30000
+}) {
+  const expectedText = readSecretFromFile(secretPath)
+
+  await sleep(delayMs)
+
+  if (readCurrentToken(statePath) !== token) {
+    return false
+  }
+
+  try {
+    const clipboardText = readClipboard()
+
+    if (typeof clipboardText !== 'string') {
+      return false
+    }
+
+    if (clipboardText === expectedText) {
+      clearClipboard()
+    }
+
+    return true
+  } finally {
+    clearCurrentTokenIfMatches(statePath, token)
+  }
+}
+
+async function main(argv = process.argv) {
+  const [, , secretPath, token, statePath, delayMsArg] = argv
+  const delayMs = Number.parseInt(delayMsArg, 10)
+
+  if (!secretPath || !token || !statePath) {
+    process.exitCode = 1
+    return
+  }
+
+  try {
+    await runClipboardCleanup({
+      secretPath,
+      token,
+      statePath,
+      delayMs: Number.isFinite(delayMs) && delayMs > 0 ? delayMs : 30000
+    })
+  } catch (err) {
+    process.stderr.write(
+      `PearPass clipboard cleanup failed: ${err && err.message ? err.message : err}\n`
+    )
+    process.exitCode = 1
+  }
+}
+
+if (require.main === module) {
+  main()
+}
+
+module.exports = {
+  clearClipboard,
+  clearCurrentTokenIfMatches,
+  logLinuxClipboardSkip,
+  main,
+  readClipboard,
+  readCurrentToken,
+  readSecretFromFile,
+  runClipboardCleanup,
+  sleep
+}

--- a/electron/clipboardCleanupHelper.test.js
+++ b/electron/clipboardCleanupHelper.test.js
@@ -1,0 +1,142 @@
+/* eslint-env jest */
+
+jest.mock('fs', () => ({
+  readFileSync: jest.fn(),
+  unlinkSync: jest.fn()
+}))
+
+jest.mock('child_process', () => ({
+  spawnSync: jest.fn()
+}))
+
+const originalPlatform = process.platform
+
+const setPlatform = (platform) => {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform
+  })
+}
+
+const loadHelper = () => {
+  jest.resetModules()
+  return require('./clipboardCleanupHelper.cjs')
+}
+
+const getFs = () => require('fs')
+const getSpawnSync = () => require('child_process').spawnSync
+
+describe('clipboardCleanupHelper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    setPlatform(originalPlatform)
+  })
+
+  it('clears the clipboard only for the latest matching token', async () => {
+    setPlatform('darwin')
+    const helper = loadHelper()
+    const fs = getFs()
+    const spawnSync = getSpawnSync()
+
+    fs.readFileSync
+      .mockReturnValueOnce('secret')
+      .mockReturnValueOnce('token-1')
+      .mockReturnValueOnce('token-1')
+
+    spawnSync
+      .mockReturnValueOnce({ status: 0, stdout: 'secret' })
+      .mockReturnValueOnce({ status: 0, stdout: '' })
+
+    const cleanupPromise = helper.runClipboardCleanup({
+      secretPath: '/tmp/secret.txt',
+      token: 'token-1',
+      statePath: '/tmp/state.token',
+      delayMs: 30000
+    })
+
+    await jest.advanceTimersByTimeAsync(30000)
+    await expect(cleanupPromise).resolves.toBe(true)
+
+    expect(spawnSync).toHaveBeenNthCalledWith(
+      1,
+      '/usr/bin/pbpaste',
+      [],
+      expect.objectContaining({ input: undefined })
+    )
+    expect(spawnSync).toHaveBeenNthCalledWith(
+      2,
+      '/usr/bin/pbcopy',
+      [],
+      expect.objectContaining({ input: '' })
+    )
+    expect(fs.unlinkSync).toHaveBeenCalledWith('/tmp/secret.txt')
+    expect(fs.unlinkSync).toHaveBeenCalledWith('/tmp/state.token')
+  })
+
+  it('does not clear when a newer clipboard token replaced it', async () => {
+    setPlatform('darwin')
+    const helper = loadHelper()
+    const fs = getFs()
+    const spawnSync = getSpawnSync()
+
+    fs.readFileSync
+      .mockReturnValueOnce('secret')
+      .mockReturnValueOnce('token-2')
+
+    const cleanupPromise = helper.runClipboardCleanup({
+      secretPath: '/tmp/secret.txt',
+      token: 'token-1',
+      statePath: '/tmp/state.token',
+      delayMs: 30000
+    })
+
+    await jest.advanceTimersByTimeAsync(30000)
+    await expect(cleanupPromise).resolves.toBe(false)
+
+    expect(spawnSync).not.toHaveBeenCalled()
+    expect(fs.unlinkSync).toHaveBeenCalledWith('/tmp/secret.txt')
+    expect(fs.unlinkSync).not.toHaveBeenCalledWith('/tmp/state.token')
+  })
+
+  it('skips Linux cleanup gracefully when no clipboard tool is available', async () => {
+    setPlatform('linux')
+    const helper = loadHelper()
+    const fs = getFs()
+    const spawnSync = getSpawnSync()
+    const stderrSpy = jest
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true)
+
+    fs.readFileSync
+      .mockReturnValueOnce('secret')
+      .mockReturnValueOnce('token-1')
+      .mockReturnValueOnce('token-1')
+
+    spawnSync
+      .mockReturnValueOnce({ error: { code: 'ENOENT' } })
+      .mockReturnValueOnce({ error: { code: 'ENOENT' } })
+
+    const cleanupPromise = helper.runClipboardCleanup({
+      secretPath: '/tmp/secret.txt',
+      token: 'token-1',
+      statePath: '/tmp/state.token',
+      delayMs: 30000
+    })
+
+    await jest.advanceTimersByTimeAsync(30000)
+    await expect(cleanupPromise).resolves.toBe(false)
+
+    expect(stderrSpy).toHaveBeenCalledWith(
+      'PearPass clipboard cleanup skipped: Linux clipboard command unavailable or failed.\n'
+    )
+    expect(fs.unlinkSync).toHaveBeenCalledWith('/tmp/secret.txt')
+    expect(fs.unlinkSync).toHaveBeenCalledWith('/tmp/state.token')
+
+    stderrSpy.mockRestore()
+  })
+})

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -7,10 +7,12 @@
 const fs = require('fs')
 const path = require('path')
 
-const { app, BrowserWindow, ipcMain, nativeImage, shell } = require('electron')
+const { app, BrowserWindow, ipcMain, nativeImage, shell, clipboard } = require('electron')
 const PearRuntime = require('pear-runtime')
+
 const getPearRuntimeLegacyStorage = require('pear-runtime-legacy-storage')
 const { isLinux, isWindows, isMac } = require('which-runtime')
+const { scheduleClipboardCleanup } = require('./clipboardCleanup.cjs')
 let debugMode = false
 
 ;(async () => {
@@ -539,6 +541,17 @@ function registerIPC() {
         code: err.code
       }
     }
+  })
+
+  ipcMain.handle('clipboard:clearAfter', async (_event, { text, delayMs }) => {
+    return scheduleClipboardCleanup({
+      app,
+      clipboard,
+      logger,
+      isWindows,
+      text,
+      delayMs
+    })
   })
 }
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -35,6 +35,8 @@ window.electronAPI = {
   applyUpdate: () => ipcRenderer.invoke('runtime:applyUpdate'),
   restart: () => ipcRenderer.invoke('runtime:restart'),
   checkUpdated: () => ipcRenderer.invoke('runtime:checkUpdated'),
+  clearClipboardAfter: (text, delayMs) =>
+    ipcRenderer.invoke('clipboard:clearAfter', { text, delayMs }),
   vaultInvoke: (method, args) =>
     ipcRenderer.invoke('vault:invoke', { method, args }),
   vaultOnUpdate: (cb) => {

--- a/electron/preload.test.js
+++ b/electron/preload.test.js
@@ -58,6 +58,7 @@ describe('preload.cjs', () => {
     expect(typeof window.electronAPI.applyUpdate).toBe('function')
     expect(typeof window.electronAPI.restart).toBe('function')
     expect(typeof window.electronAPI.checkUpdated).toBe('function')
+    expect(typeof window.electronAPI.clearClipboardAfter).toBe('function')
     expect(typeof window.electronAPI.vaultInvoke).toBe('function')
     expect(typeof window.electronAPI.vaultOnUpdate).toBe('function')
   })
@@ -70,12 +71,17 @@ describe('preload.cjs', () => {
     await window.electronAPI.applyUpdate()
     await window.electronAPI.restart()
     await window.electronAPI.checkUpdated()
+    await window.electronAPI.clearClipboardAfter('secret', 30000)
 
     expect(ipcRenderer.invoke).toHaveBeenCalledWith('app:getVersion')
     expect(ipcRenderer.invoke).toHaveBeenCalledWith('runtime:getConfig')
     expect(ipcRenderer.invoke).toHaveBeenCalledWith('runtime:applyUpdate')
     expect(ipcRenderer.invoke).toHaveBeenCalledWith('runtime:restart')
     expect(ipcRenderer.invoke).toHaveBeenCalledWith('runtime:checkUpdated')
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith('clipboard:clearAfter', {
+      text: 'secret',
+      delayMs: 30000
+    })
   })
 
   it('routes vaultInvoke through ipcRenderer.invoke with payload', async () => {

--- a/src/hooks/useCopyToClipboard.electron.js
+++ b/src/hooks/useCopyToClipboard.electron.js
@@ -5,6 +5,8 @@
  */
 import React, { useState, useEffect } from 'react'
 
+import { CLIPBOARD_CLEAR_TIMEOUT } from 'pearpass-lib-constants'
+
 import { LOCAL_STORAGE_KEYS } from '../constants/localStorage'
 import { logger } from '../utils/logger'
 
@@ -38,7 +40,13 @@ export const useCopyToClipboard = ({ onCopy } = {}) => {
       () => {
         setIsCopied(true)
         onCopy?.()
-        // Clear-after-delay could be added via electronAPI.clearClipboardAfter(delayMs) in main
+        // Clear clipboard automatically after delay
+        if (window.electronAPI) {
+          window.electronAPI.clearClipboardAfter?.(
+            text,
+            CLIPBOARD_CLEAR_TIMEOUT
+          )
+        }
       },
       (err) => {
         logger.error(

--- a/src/hooks/useCopyToClipboard.electron.test.js
+++ b/src/hooks/useCopyToClipboard.electron.test.js
@@ -1,4 +1,5 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
+import { CLIPBOARD_CLEAR_TIMEOUT } from 'pearpass-lib-constants'
 
 import { useCopyToClipboard } from './useCopyToClipboard.electron'
 import { LOCAL_STORAGE_KEYS } from '../constants/localStorage'
@@ -14,6 +15,9 @@ describe('useCopyToClipboard.electron', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     localStorage.clear()
+    window.electronAPI = {
+      clearClipboardAfter: jest.fn()
+    }
 
     Object.defineProperty(navigator, 'clipboard', {
       configurable: true,
@@ -83,6 +87,10 @@ describe('useCopyToClipboard.electron', () => {
       expect(result.current.isCopied).toBe(true)
       expect(onCopy).toHaveBeenCalledTimes(1)
     })
+    expect(window.electronAPI.clearClipboardAfter).toHaveBeenCalledWith(
+      'secret',
+      CLIPBOARD_CLEAR_TIMEOUT
+    )
   })
 
   it('logs and returns false when text is invalid', async () => {


### PR DESCRIPTION
### Requirements
<!-- List the requirements for this PR -->

### Changes

Added in cleanup from the renderer through electronAPI, that lets the main process launch a detached helper for clipboard clearing.

The copied value is passed through a temp file, which the helper deletes right after reading. Also added a token and save it in a small state file so each cleanup job can check whether it is still the latest one before clearing the clipboard. This prevents an older cleanup job from clearing a newer copied value too early if the user copies again before the previous 30-second timeout finishes.

### Screenshots/Recordings


https://github.com/user-attachments/assets/e7b72f14-ea58-4607-8a01-10ffaaa46b3d



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213703443323075