### PR TITLE
fix: remove GH token for mac

### DIFF
--- a/.github/workflows/build-appling.yaml
+++ b/.github/workflows/build-appling.yaml
@@ -143,7 +143,6 @@ jobs:
           MAC_CODESIGN_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
           CSC_NAME: ${{ secrets.MACOS_SIGNING_IDENTITY }}
           PEARPASS_UPGRADE_LINK: ${{ vars.PEARPASS_UPGRADE_LINK }}
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           npm run dist:mac:${{ matrix.arch }}
 


### PR DESCRIPTION
### Changes

- Fixes the issue when electron builder auto publishes release to GH