### PR TITLE
fix: switch from global to local install for electron builder

### DIFF
--- a/.github/workflows/build-appling.yaml
+++ b/.github/workflows/build-appling.yaml
@@ -36,9 +36,9 @@ jobs:
           npm prune --omit=dev
       - name: Setup Electron and Builder
         run: |
-          npm install -g electron
-          npm install -g electron-builder
-          npm install -g pear-build
+          npm install electron --no-save
+          npm install electron-builder --no-save
+          npm install pear-build --no-save
       - name: Build application
         env:
           PEARPASS_UPGRADE_LINK: ${{ vars.PEARPASS_UPGRADE_LINK }}


### PR DESCRIPTION
### Changes

- Fixes the issue when electron builder doesn't accept globally installed electron

> Cannot compute electron version from installed node modules - none of the possible electron modules are installed and version ("^33.0.0") is not fixed in project.
