### PR TITLE
Firefox support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5675,7 +5675,7 @@
     "node_modules/@tetherto/pearpass-lib-constants": {
       "name": "pearpass-lib-constants",
       "version": "0.0.11",
-      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-constants.git#19a6e1d244fca97e73d653ab58a3125f2ef2da1c",
+      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-constants.git#ba83d9bcbb0282ac44ce9907d45d5f5c0e4d0066",
       "license": "Apache-2.0"
     },
     "node_modules/@tetherto/pearpass-lib-data-export": {
@@ -5715,13 +5715,14 @@
     "node_modules/@tetherto/pearpass-lib-ui-kit": {
       "name": "pearpass-lib-ui-react-native-components",
       "version": "0.0.40",
-      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-ui-react-native-components.git#d881750ab579623f9f1d418192802c31779a94dd",
+      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-ui-react-native-components.git#84731f12789384b1ab366ee324e97847a02ea41d",
       "license": "Apache-2.0",
       "dependencies": {
         "react-strict-dom": "^0.0.55"
       },
       "peerDependencies": {
         "@gorhom/bottom-sheet": "^5.1.1",
+        "@react-native-community/datetimepicker": "^8.4.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-native": "0.79.5",
@@ -5943,22 +5944,6 @@
       "optional": true,
       "dependencies": {
         "ms": "2.0.0"
-      }
-    },
-    "node_modules/@tetherto/pearpass-lib-ui-theme-provider/node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "queue": "6.0.2"
-      },
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
       }
     },
     "node_modules/@tetherto/pearpass-lib-ui-theme-provider/node_modules/import-fresh": {
@@ -14824,6 +14809,22 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
     },
     "node_modules/immediate": {
       "version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "postinstall": "node scripts/patch-electron-dock-name.mjs",
     "watch:packages": "nodemon --watch packages --ext js,json --exec \"echo 'Packages changed'\"",
     "electron": "electron .",
-    "dev": "concurrently -n \"TypeScript,Bundle,Electron\" -c \"blue,cyan,green\" \"node node_modules/typescript/bin/tsc --watch\" \"node scripts/bundle-renderer.mjs --watch\" \"wait-on dist/renderer.bundle.js && electron .\"",
+    "dev": "concurrently -n \"TypeScript,Bundle,Bridge,Electron\" -c \"blue,cyan,magenta,green\" \"node node_modules/typescript/bin/tsc --watch\" \"node scripts/bundle-renderer.mjs --watch\" \"node scripts/bundle-bridge.mjs --watch\" \"wait-on dist/renderer.bundle.js && electron .\"",
     "dev:reset": "PEARPASS_DEV_RESET=1 npm run dev",
     "dist:prepare:dev": "npm install && npm run build && npm prune --omit=dev && npm install electron --no-save",
     "dist:mac:arm64": "npx electron-builder --mac --arm64 -c electron-builder.mac.json --publish never",

--- a/scripts/bundle-bridge.mjs
+++ b/scripts/bundle-bridge.mjs
@@ -9,8 +9,9 @@ import { fileURLToPath } from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const root = path.join(__dirname, '..')
+const watch = process.argv.includes('--watch')
 
-esbuild.build({
+const ctx = await esbuild.context({
   entryPoints: [
     path.join(
       root,
@@ -37,4 +38,12 @@ esbuild.build({
     'pear-ipc'
   ],
   logLevel: 'info'
-}).catch(() => process.exit(1))
+})
+
+if (watch) {
+  await ctx.watch()
+  console.log('Watching for changes...')
+} else {
+  await ctx.rebuild()
+  ctx.dispose()
+}

--- a/src/utils/nativeMessagingSetup.js
+++ b/src/utils/nativeMessagingSetup.js
@@ -3,7 +3,11 @@ import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
 
-import { MANIFEST_NAME, EXTENSION_ID } from '@tetherto/pearpass-lib-constants'
+import {
+  MANIFEST_NAME,
+  EXTENSION_ID,
+  FIREFOX_EXTENSION_ID
+} from '@tetherto/pearpass-lib-constants'
 
 import { logger } from './logger'
 import flatpakPaths from '../../electron/flatpak-paths.cjs'
@@ -238,18 +242,40 @@ export const getNativeMessagingLocations = () => {
             'NativeMessagingHosts',
             manifestFile
           )
+        },
+        {
+          name: 'Firefox',
+          isFirefox: true,
+          browserDir: path.join(
+            home,
+            'Library',
+            'Application Support',
+            'Mozilla'
+          ),
+          manifestPath: path.join(
+            home,
+            'Library',
+            'Application Support',
+            'Mozilla',
+            'NativeMessagingHosts',
+            manifestFile
+          )
         }
       )
       break
 
     case 'win32': {
-      const manifestPath = path.join(
+      const nativeMessagingDir = path.join(
         home,
         'AppData',
         'Local',
         'PearPass',
-        'NativeMessaging',
-        manifestFile
+        'NativeMessaging'
+      )
+      const manifestPath = path.join(nativeMessagingDir, manifestFile)
+      const firefoxManifestPath = path.join(
+        nativeMessagingDir,
+        `${MANIFEST_NAME}.firefox.json`
       )
       browsers.push(
         {
@@ -275,6 +301,13 @@ export const getNativeMessagingLocations = () => {
           browserDir: null,
           manifestPath,
           registryKey: `HKCU\\Software\\BraveSoftware\\Brave-Browser\\NativeMessagingHosts\\${MANIFEST_NAME}`
+        },
+        {
+          name: 'Firefox',
+          isFirefox: true,
+          browserDir: null,
+          manifestPath: firefoxManifestPath,
+          registryKey: `HKCU\\Software\\Mozilla\\NativeMessagingHosts\\${MANIFEST_NAME}`
         }
       )
       break
@@ -357,6 +390,17 @@ export const getNativeMessagingLocations = () => {
             'BraveSoftware',
             'Brave-Browser',
             'NativeMessagingHosts',
+            manifestFile
+          )
+        },
+        {
+          name: 'Firefox',
+          isFirefox: true,
+          browserDir: path.join(home, '.mozilla'),
+          manifestPath: path.join(
+            home,
+            '.mozilla',
+            'native-messaging-hosts',
             manifestFile
           )
         }
@@ -514,13 +558,22 @@ export const setupNativeMessaging = async ({
 
     const extensionId = localStorage.getItem('EXTENSION_ID') || EXTENSION_ID
 
-    // Create native messaging manifest
-    const manifest = {
+    // Create Chromium native messaging manifest
+    const chromiumManifest = {
       name: MANIFEST_NAME,
       description: 'PearPass Native Messaging Host',
       path: executablePath,
       type: 'stdio',
       allowed_origins: [`chrome-extension://${extensionId}/`]
+    }
+
+    // Create Firefox native messaging manifest
+    const firefoxManifest = {
+      name: MANIFEST_NAME,
+      description: 'PearPass Native Messaging Host',
+      path: executablePath,
+      type: 'stdio',
+      allowed_extensions: [FIREFOX_EXTENSION_ID]
     }
 
     const { browsers } = getNativeMessagingLocations()
@@ -541,6 +594,7 @@ export const setupNativeMessaging = async ({
       }
 
       try {
+        const manifest = browser.isFirefox ? firefoxManifest : chromiumManifest
         await fs.mkdir(path.dirname(browser.manifestPath), { recursive: true })
         await fs.writeFile(
           browser.manifestPath,

--- a/src/utils/nativeMessagingSetup.js
+++ b/src/utils/nativeMessagingSetup.js
@@ -5,7 +5,7 @@ import path from 'path'
 
 import {
   MANIFEST_NAME,
-  EXTENSION_ID,
+  CHROMIUM_EXTENSION_ID,
   FIREFOX_EXTENSION_ID
 } from '@tetherto/pearpass-lib-constants'
 
@@ -556,7 +556,8 @@ export const setupNativeMessaging = async ({
       throw new Error(execResult.message)
     }
 
-    const extensionId = localStorage.getItem('EXTENSION_ID') || EXTENSION_ID
+    const extensionId =
+      localStorage.getItem('CHROMIUM_EXTENSION_ID') || CHROMIUM_EXTENSION_ID
 
     // Create Chromium native messaging manifest
     const chromiumManifest = {

--- a/src/utils/nativeMessagingSetup.test.js
+++ b/src/utils/nativeMessagingSetup.test.js
@@ -15,7 +15,7 @@ import {
 // Mock dependencies
 jest.mock('@tetherto/pearpass-lib-constants', () => ({
   MANIFEST_NAME: 'com.pearpass.native_messaging',
-  EXTENSION_ID: 'mock-extension-id'
+  CHROMIUM_EXTENSION_ID: 'mock-extension-id'
 }))
 jest.mock('os')
 jest.mock('fs/promises')


### PR DESCRIPTION
### Changes
- Add Firefox to native messaging targets: install `allowed_extensions` manifest at Firefox-specific paths on macOS (`~/Library/Application Support/Mozilla/NativeMessagingHosts/`), Linux (`~/.mozilla/native-messaging-hosts/`), and via Windows registry (`HKCU\Software\Mozilla\NativeMessagingHosts`). Chromium manifests continue to install alongside with `allowed_origins`.
- Rename `EXTENSION_ID` to `CHROMIUM_EXTENSION_ID` to disambiguate from the new `FIREFOX_EXTENSION_ID`.
- Bump `@tetherto/pearpass-lib-constants` ref to pick up the new Firefox extension ID constant.
- Add native messaging bridge bundler (`scripts/bundle-bridge.mjs --watch`) to the `dev` script so the bridge bundle stays in sync with source changes without a manual rebuild.

### Screenshots/Recordings

- Regression test on Chrome

https://github.com/user-attachments/assets/fa4c489b-1186-4233-9203-e25b722dfbcc

- Test on Firefox

https://github.com/user-attachments/assets/e9e9fd8c-e008-40af-863c-72f71c9fe966


### Dependencies

- https://github.com/tetherto/pearpass-app-browser-extension/pull/154