### PR TITLE
fix: broken Pear doc link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ PearPass is a distributed password manager powered by Pear Runtime. It allows se
 node --version
 ```
 
-- **Pear**: Ensure you have Pear installed mode details can be found [here](https://docs.pears.com/guides)
+- **Pear**: Ensure you have Pear installed. More details can be found [here](https://docs.pears.com/guide/getting-started.html)
 
 
 Clone the repository


### PR DESCRIPTION
### Requirements
- Fix broken link in README pointing to the Pear setup/getting-started documentation

### Changes
- Updated the URL to point to the correct Getting Started documentation

### Testing Notes
- Verified the updated link redirects correctly to the official Pear Getting Started page
- Checked README rendering on GitHub to confirm the link works as expected

### Things reviewers should pay attention to
- Confirm the updated link points to the correct and current Pear documentation

### Screenshots/Recordings
- Not applicable (documentation-only change)

### dependencies
- None
