### PR TITLE
docs(readme): fix broken Pear documentation link (and 'installed mode' grammar)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ PearPass is a distributed password manager powered by Pear Runtime. It allows se
 node --version
 ```
 
-- **Pear**: Ensure you have Pear installed mode details can be found [here](https://docs.pears.com/guides)
+- **Pear**: Ensure you have Pear installed. More details can be found at [pears.com](https://pears.com/).
 
 
 Clone the repository


### PR DESCRIPTION
## Summary

README prerequisites linked to \`https://docs.pears.com/guides\`, which 404s. Two fixes on the same line:

- Point to [pears.com](https://pears.com/) instead — the main Pear Runtime site (which the README already references on line 122 under *Resources*).
- Fix the sentence: \"Ensure you have Pear installed mode details can be found [here]\" -> \"Ensure you have Pear installed. More details can be found at [pears.com]\".

Happy to target a specific \`docs.pears.com\` page instead if the team has a preferred install guide URL.

Closes #426

## Testing

Docs-only change; one line.