### PR TITLE
Create items bugs

### DIFF
--- a/src/components/FolderDropdown/FolderDropdownV2.tsx
+++ b/src/components/FolderDropdown/FolderDropdownV2.tsx
@@ -1,13 +1,15 @@
-import React, { useMemo } from 'react'
+import { useMemo } from 'react'
 
 import {
+  Button,
   ContextMenu,
   MultiSlotInput,
   NavbarListItem,
   SelectField,
+  rawTokens,
   useTheme
 } from '@tetherto/pearpass-lib-ui-kit'
-import { CreateNewFolder, Folder, KeyboardArrowBottom } from '@tetherto/pearpass-lib-ui-kit/icons'
+import { Close, CreateNewFolder, Folder, KeyboardArrowBottom } from '@tetherto/pearpass-lib-ui-kit/icons'
 import { useFolders } from '@tetherto/pearpass-lib-vault'
 
 import { CreateFolderModalContentV2 } from '../../containers/Modal/CreateFolderModalContentV2/CreateFolderModalContentV2'
@@ -60,7 +62,29 @@ export const FolderDropdownV2 = ({
             placeholder={t('Choose Folder')}
             testID='createoredit-select-folder-v2'
             rightSlot={
-              <KeyboardArrowBottom color={theme.colors.colorTextPrimary} />
+              <div style={{ display: 'flex', alignItems: 'center', gap: rawTokens.spacing6 }}>
+                {selectedFolder && (
+                  <Button
+                    variant='tertiary'
+                    size='small'
+                    type='button'
+                    aria-label={t('Clear folder')}
+                    iconBefore={
+                      <Close
+                        width={16}
+                        height={16}
+                        color={theme.colors.colorTextPrimary}
+                      />
+                    }
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onFolderSelect(selectedFolder)
+                    }}
+                    data-testid='createoredit-folder-clear-v2'
+                  />
+                )}
+                <KeyboardArrowBottom color={theme.colors.colorTextPrimary} />
+              </div>
             }
           />
         </MultiSlotInput>
@@ -99,3 +123,4 @@ export const FolderDropdownV2 = ({
     </ContextMenu>
   )
 }
+

--- a/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditCreditCardModalContentV2/CreateOrEditCreditCardModalContentV2.tsx
+++ b/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditCreditCardModalContentV2/CreateOrEditCreditCardModalContentV2.tsx
@@ -230,7 +230,7 @@ export const CreateOrEditCreditCardModalContentV2 = ({
             variant="primary"
             size="small"
             type="button"
-            disabled={isLoading}
+            disabled={isLoading || (!isEdit && !values.title?.trim())}
             isLoading={isLoading}
             onClick={() => handleSubmit(onSubmit)()}
             data-testid="createoredit-creditcard-button-save-v2"

--- a/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditCustomModalContentV2/CreateOrEditCustomModalContentV2.tsx
+++ b/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditCustomModalContentV2/CreateOrEditCustomModalContentV2.tsx
@@ -190,7 +190,7 @@ export const CreateOrEditCustomModalContentV2 = ({
             variant="primary"
             size="small"
             type="button"
-            disabled={isLoading}
+            disabled={isLoading || (!isEdit && !values.title?.trim())}
             isLoading={isLoading}
             onClick={() => handleSubmit(onSubmit)()}
             data-testid="createoredit-custom-button-save-v2"

--- a/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditIdentityModalContentV2/CreateOrEditIdentityModalContentV2.tsx
+++ b/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditIdentityModalContentV2/CreateOrEditIdentityModalContentV2.tsx
@@ -314,7 +314,7 @@ export const CreateOrEditIdentityModalContentV2 = ({
             variant="primary"
             size="small"
             type="button"
-            disabled={isLoading}
+            disabled={isLoading || (!isEdit && !values.title?.trim())}
             isLoading={isLoading}
             onClick={() => handleSubmit(onSubmit)()}
             data-testid="createoredit-identity-button-save-v2"

--- a/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditLoginModalContentV2/CreateOrEditLoginModalContentV2.tsx
+++ b/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditLoginModalContentV2/CreateOrEditLoginModalContentV2.tsx
@@ -253,7 +253,7 @@ export const CreateOrEditLoginModalContentV2 = ({
             variant='primary'
             size='small'
             type='button'
-            disabled={isLoading}
+            disabled={isLoading || (!isEdit && !values.title?.trim())}
             isLoading={isLoading}
             onClick={() => handleSubmit(onSubmit)()}
             data-testid='createoredit-button-save-v2'

--- a/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditNoteModalContentV2/CreateOrEditNoteModalContentV2.tsx
+++ b/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditNoteModalContentV2/CreateOrEditNoteModalContentV2.tsx
@@ -196,7 +196,7 @@ export const CreateOrEditNoteModalContentV2 = ({
             variant="primary"
             size="small"
             type="button"
-            disabled={isLoading}
+            disabled={isLoading || (!isEdit && !values.title?.trim())}
             isLoading={isLoading}
             onClick={() => handleSubmit(onSubmit)()}
             data-testid="createoredit-note-button-save-v2"

--- a/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditPassPhraseModalContentV2/CreateOrEditPassPhraseModalContentV2.tsx
+++ b/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditPassPhraseModalContentV2/CreateOrEditPassPhraseModalContentV2.tsx
@@ -183,7 +183,7 @@ export const CreateOrEditPassPhraseModalContentV2 = ({
             variant="primary"
             size="small"
             type="button"
-            disabled={isLoading}
+            disabled={isLoading || (!isEdit && (!values.title?.trim() || !values.passPhrase?.trim()))}
             isLoading={isLoading}
             onClick={() => handleSubmit(onSubmit)()}
             data-testid="createoredit-passphrase-button-save-v2"

--- a/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditWifiModalContentV2/CreateOrEditWifiModalContentV2.tsx
+++ b/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditWifiModalContentV2/CreateOrEditWifiModalContentV2.tsx
@@ -168,7 +168,7 @@ export const CreateOrEditWifiModalContentV2 = ({
             variant="primary"
             size="small"
             type="button"
-            disabled={isLoading}
+            disabled={isLoading || (!isEdit && (!values.title?.trim() || !values.password?.trim()))}
             isLoading={isLoading}
             onClick={() => handleSubmit(onSubmit)()}
             data-testid="createoredit-wifi-button-save-v2"


### PR DESCRIPTION
### Requirements
<!-- List the requirements for this PR -->
[v2][MacOS/Windows/Ubuntu][Creating Item] The "Add Item" button is enabled when there are empty fields
[v2][MacOS/Windows/Ubuntu][Item Edit/Create mode] Once an item is placed into a folder, it cannot be made folderless again in edit mode
### Changes
<!-- Summarize the changes introduced in this PR -->

### Testing Notes
<!-- How did you test it? -->

### Things reviewers should pay attention to
<!-- Highlight anything specific you want reviewers to focus on -->

### Screenshots/Recordings
<!-- Add screenshots or screen recordings if applicable -->

https://github.com/user-attachments/assets/bd08e3cc-3bd5-480a-840b-6ce8ce1d0870


https://github.com/user-attachments/assets/015f1d29-088e-44ef-a960-34dbd0c3bfc5


### dependencies
<!-- List any dependent work items or PRs -->
