### PR TITLE
Home screen bug fixes

### DIFF
--- a/app.electron.tsx
+++ b/app.electron.tsx
@@ -2,6 +2,7 @@
  * Electron-only entry for the renderer bundle (nodeIntegration: true).
  */
 import { i18n } from '@lingui/core'
+import { compileMessage } from '@lingui/message-utils/compileMessage'
 import { I18nProvider } from '@lingui/react'
 import { ThemeProvider } from '@tetherto/pearpass-lib-ui-theme-provider'
 import {
@@ -29,6 +30,7 @@ import { AutoLockProvider } from './src/hooks/useAutoLockPreferences'
 import { DEBUG_MODE } from './src/constants/appConstants'
 
 setFontsAndResetCSS()
+i18n.setMessagesCompiler(compileMessage)
 i18n.load('en', messages)
 i18n.activate('en')
 

--- a/src/app/Routes/index.js
+++ b/src/app/Routes/index.js
@@ -76,20 +76,10 @@ export const Routes = ({
           mainView=${isAuthenticator
             ? html`<${AuthenticatorView} />`
             : html`<${VersionBasedMainView} />`}
-          sideView=${getSideView(currentPage, data)}
+          sideView=${html`<${RecordDetails} />`}
+          isSideViewOpen=${!!data?.recordId}
         />
       <//>
     `
-  }
-}
-
-/**
- * @param {string} currentPage
- * @param {import('../../context/RouterContext').RouterData} data
- * @returns {import('react').ReactNode}
- */
-function getSideView(currentPage, data) {
-  if (currentPage === 'vault' && data?.recordId) {
-    return html` <${RecordDetails} /> `
   }
 }

--- a/src/containers/EmptyCollectionViewV2/EmptyCollectionViewV2.tsx
+++ b/src/containers/EmptyCollectionViewV2/EmptyCollectionViewV2.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import { Button, Text, Title, useTheme } from '@tetherto/pearpass-lib-ui-kit'
 import { Add, ImportExport } from '@tetherto/pearpass-lib-ui-kit/icons'
@@ -9,15 +9,27 @@ import {
 } from './EmptyCollectionViewV2.styles'
 import { useAppHeaderContext } from '../../context/AppHeaderContext'
 import { useRouter } from '../../context/RouterContext'
+import { useRecordMenuItemsV2 } from '../../hooks/useRecordMenuItemsV2'
 import { useTranslation } from '../../hooks/useTranslation'
 import { SettingsItemKey } from '../../pages/SettingsViewV2/SettingsViewV2'
 import { ItemCardIllustration } from '../../svgs/ItemCardIllustration'
 
-export const EmptyCollectionViewV2 = () => {
+type EmptyCollectionViewV2Props = {
+  recordType?: string
+  selectedFolder?: string
+  isFavoritesView?: boolean
+}
+
+export const EmptyCollectionViewV2 = ({
+  recordType = 'all',
+  selectedFolder,
+  isFavoritesView = false
+}: EmptyCollectionViewV2Props) => {
   const { t } = useTranslation()
   const { theme } = useTheme()
   const { navigate } = useRouter()
   const { setIsAddMenuOpen } = useAppHeaderContext()
+  const { categoriesItems } = useRecordMenuItemsV2()
   const styles = createStyles()
 
   const handleAddItem = () => {
@@ -28,6 +40,52 @@ export const EmptyCollectionViewV2 = () => {
     navigate('settings', { initialTab: SettingsItemKey.ImportItems })
   }
 
+  const categoryLabel = categoriesItems.find(
+    (item) => item.type === recordType
+  )?.label
+
+  const { title, descriptionParagraphs } = useMemo<{
+    title: string
+    descriptionParagraphs: string[]
+  }>(() => {
+    if (isFavoritesView) {
+      return {
+        title: t('No favorite items'),
+        descriptionParagraphs: [t('Mark items as favorites')]
+      }
+    }
+
+    if (selectedFolder) {
+      return {
+        title: t('Empty folder'),
+        descriptionParagraphs: [
+          t('Start adding items or save existing ones in the {folder} folder', {
+            folder: selectedFolder
+          })
+        ]
+      }
+    }
+
+    if (recordType !== 'all' && categoryLabel) {
+      return {
+        title: t('No item of type {category}', { category: categoryLabel }),
+        descriptionParagraphs: [
+          t('Start adding items of type {category} in your vault', {
+            category: categoryLabel
+          })
+        ]
+      }
+    }
+
+    return {
+      title: t('No item saved'),
+      descriptionParagraphs: [
+        t('Start using PearPass by creating your first item'),
+        t('or import your items from a different password manager')
+      ]
+    }
+  }, [isFavoritesView, selectedFolder, recordType, categoryLabel, t])
+
   return (
     <div style={styles.container} data-testid="empty-collection-v2">
       <div style={styles.content}>
@@ -37,66 +95,59 @@ export const EmptyCollectionViewV2 = () => {
 
         <div style={styles.textBlock}>
           <Title as="h2" data-testid="empty-collection-v2-title">
-            {t('No item saved')}
+            {title}
           </Title>
-          <Text
-            as="p"
-            variant="label"
-            color={theme.colors.colorTextSecondary}
-            style={
-              styles.descriptionParagraph as unknown as React.ComponentProps<
-                typeof Text
-              >['style']
-            }
-          >
-            {t('Start using PearPass by creating your first item')}
-          </Text>
-          <Text
-            as="p"
-            variant="label"
-            color={theme.colors.colorTextSecondary}
-            style={
-              styles.descriptionParagraph as unknown as React.ComponentProps<
-                typeof Text
-              >['style']
-            }
-          >
-            {t('or import your items from a different password manager')}
-          </Text>
+          {descriptionParagraphs.map((paragraph, index) => (
+            <Text
+              key={index}
+              as="p"
+              variant="label"
+              color={theme.colors.colorTextSecondary}
+              style={
+                styles.descriptionParagraph as unknown as React.ComponentProps<
+                  typeof Text
+                >['style']
+              }
+            >
+              {paragraph}
+            </Text>
+          ))}
         </div>
 
-        <div style={styles.ctas}>
-          <div style={styles.ctaButton}>
-            <Button
-              variant="primary"
-              size="small"
-              fullWidth
-              data-testid="empty-collection-v2-add"
-              iconBefore={<Add width={16} height={16} />}
-              onClick={handleAddItem}
-            >
-              {t('Add Item')}
-            </Button>
+        {!isFavoritesView && (
+          <div style={styles.ctas}>
+            <div style={styles.ctaButton}>
+              <Button
+                variant="primary"
+                size="small"
+                fullWidth
+                data-testid="empty-collection-v2-add"
+                iconBefore={<Add width={16} height={16} />}
+                onClick={handleAddItem}
+              >
+                {t('Add Item')}
+              </Button>
+            </div>
+            <div style={styles.ctaButton}>
+              <Button
+                variant="secondary"
+                size="small"
+                fullWidth
+                data-testid="empty-collection-v2-import"
+                iconBefore={
+                  <ImportExport
+                    width={16}
+                    height={16}
+                    color={theme.colors.colorTextPrimary}
+                  />
+                }
+                onClick={handleImport}
+              >
+                {t('Import Items')}
+              </Button>
+            </div>
           </div>
-          <div style={styles.ctaButton}>
-            <Button
-              variant="secondary"
-              size="small"
-              fullWidth
-              data-testid="empty-collection-v2-import"
-              iconBefore={
-                <ImportExport
-                  width={16}
-                  height={16}
-                  color={theme.colors.colorTextPrimary}
-                />
-              }
-              onClick={handleImport}
-            >
-              {t('Import Items')}
-            </Button>
-          </div>
-        </div>
+        )}
       </div>
     </div>
   )

--- a/src/containers/LayoutWithSidebar/index.js
+++ b/src/containers/LayoutWithSidebar/index.js
@@ -16,13 +16,14 @@ import { SidebarV2 } from '../Sidebar/SidebarV2'
  * @typedef LayoutWithSidebarProps
  * @property {import('react').ReactNode} mainView
  * @property {import('react').ReactNode} sideView
+ * @property {boolean} isSideViewOpen
  */
 
 /**
  * @param {LayoutWithSidebarProps} props
  */
 
-export const LayoutWithSidebar = ({ mainView, sideView }) => {
+export const LayoutWithSidebar = ({ mainView, sideView, isSideViewOpen }) => {
   const { theme } = useTheme()
   const isV2Design = isV2()
   const VersionBasedContentWrapper = isV2Design
@@ -30,10 +31,17 @@ export const LayoutWithSidebar = ({ mainView, sideView }) => {
     : ContentWrapper
 
   const v2SideViewStyle = {
-    flex: 1,
-    overflowY: 'auto',
+    flexBasis: 0,
+    flexShrink: 1,
+    flexGrow: isSideViewOpen ? 1 : 0,
+    minWidth: 0,
+    overflowX: 'hidden',
+    overflowY: isSideViewOpen ? 'auto' : 'hidden',
     backgroundColor: theme.colors.colorSurfacePrimary,
-    borderLeft: `1px solid ${theme.colors.colorBorderPrimary}`
+    borderLeftWidth: isSideViewOpen ? 1 : 0,
+    borderLeftStyle: 'solid',
+    borderLeftColor: theme.colors.colorBorderPrimary,
+    transition: 'flex-grow 150ms ease, border-left-width 150ms ease'
   }
 
   return html`
@@ -44,10 +52,11 @@ export const LayoutWithSidebar = ({ mainView, sideView }) => {
 
       <${VersionBasedContentWrapper}> ${mainView} <//>
 
-      ${sideView &&
-      (isV2Design
-        ? html`<div style=${v2SideViewStyle}>${sideView}</div>`
-        : html`<${SideViewWrapper}>${sideView}<//>`)}
+      ${isV2Design
+        ? sideView && html`<div style=${v2SideViewStyle}>${sideView}</div>`
+        : isSideViewOpen && sideView
+          ? html`<${SideViewWrapper}>${sideView}<//>`
+          : null}
     <//>
   `
 }

--- a/src/containers/Modal/DeleteFolderModalContentV2/DeleteFolderModalContentV2.styles.ts
+++ b/src/containers/Modal/DeleteFolderModalContentV2/DeleteFolderModalContentV2.styles.ts
@@ -4,6 +4,7 @@ export const createStyles = () => ({
   body: {
     display: 'flex' as const,
     flexDirection: 'column' as const,
-    gap: `${rawTokens.spacing16}px`
+    gap: `${rawTokens.spacing16}px`,
+    whiteSpace: 'pre-line' as const
   }
 })

--- a/src/containers/Modal/DeleteFolderModalContentV2/DeleteFolderModalContentV2.tsx
+++ b/src/containers/Modal/DeleteFolderModalContentV2/DeleteFolderModalContentV2.tsx
@@ -83,16 +83,16 @@ export const DeleteFolderModalContentV2 = ({
             value: DeleteOption.DeleteFolder,
             label: t('Delete Folder'),
             description: t(
-              'Only the folder will be removed. Your items will be moved to the All Folder list.'
+              'Only the folder will be removed.\nYour items will be moved to the All Folder list.'
             )
           }
         ]
       : []),
     {
       value: DeleteOption.DeleteFolderAndItems,
-      label: t('Delete folder and items'),
+      label: t('Delete Folder and Items'),
       description: t(
-        'This will permanently remove the folder and all {count} items inside. This action cannot be undone.',
+        'This will permanently remove the folder and all {count} items inside.\nThis action cannot be undone.',
         { count }
       )
     }

--- a/src/containers/Modal/MoveFolderModalContentV2/MoveFolderModalContentV2.tsx
+++ b/src/containers/Modal/MoveFolderModalContentV2/MoveFolderModalContentV2.tsx
@@ -98,17 +98,20 @@ export const MoveFolderModalContentV2 = ({
     ]
   }, [folders, iconColor, t])
 
-  const recordIdsKey = records.map((r) => r.id).sort().join(',')
-  const customFoldersListKey = Object.keys(
-    (folders?.customFolders ?? {}) as Record<string, unknown>
-  )
-    .sort()
-    .join(',')
-  const [selectedId, setSelectedId] = useState<string | null>(null)
+  // Preselect the chip the records currently sit at
+  const defaultSelectedId = useMemo<string | null>(() => {
+    if (records.length === 0) return null
+    const firstFolder = records[0].folder
+    if (!records.every((r) => r.folder === firstFolder)) return null
+    if (!firstFolder) return CHIP_ID_ALL
+    return folders?.customFolders?.[firstFolder] ? firstFolder : null
+  }, [records, folders])
+
+  const [selectedId, setSelectedId] = useState<string | null>(defaultSelectedId)
 
   useEffect(() => {
-    setSelectedId(null)
-  }, [recordIdsKey, customFoldersListKey])
+    setSelectedId(defaultSelectedId)
+  }, [defaultSelectedId])
 
   const atDestination =
     !!selectedId &&

--- a/src/containers/Modal/MoveFolderModalContentV2/MoveFolderModalContentV2.tsx
+++ b/src/containers/Modal/MoveFolderModalContentV2/MoveFolderModalContentV2.tsx
@@ -12,8 +12,10 @@ import { useModal } from '../../../context/ModalContext'
 import { useGlobalLoading } from '../../../context/LoadingContext'
 import { useScrollOverflow } from '../../../hooks/useScrollOverflow'
 import { useTranslation } from '../../../hooks/useTranslation'
-import { Folder } from '@tetherto/pearpass-lib-ui-kit/icons'
+import { Folder, Layers } from '@tetherto/pearpass-lib-ui-kit/icons'
 import { RecordAvatar } from '../../../components/RecordAvatar'
+
+const CHIP_ID_ALL = '__all__'
 
 export type MoveFolderRecord = Record<string, unknown> & {
   id: string
@@ -63,7 +65,7 @@ export const MoveFolderModalContentV2 = ({
 
   const { data: folders, isLoading: isLoadingFolders } = useFolders()
 
-  const { updateFolder, isLoading: isUpdating } = useRecords({
+  const { updateFolder, updateRecords, isLoading: isUpdating } = useRecords({
     onCompleted: closeModal
   })
 
@@ -78,14 +80,23 @@ export const MoveFolderModalContentV2 = ({
       (folders?.customFolders ?? {}) as Record<string, { name: string }>
     )
 
-    return customFolders
+    const customOptions = customFolders
       .sort((a, b) => a.name.localeCompare(b.name))
       .map(({ name }) => ({
         id: name,
         label: name,
         icon: <Folder width={20} height={20} style={{ color: iconColor }} />
       }))
-  }, [folders, iconColor])
+
+    return [
+      {
+        id: CHIP_ID_ALL,
+        label: t('All Items'),
+        icon: <Layers width={20} height={20} style={{ color: iconColor }} />
+      },
+      ...customOptions
+    ]
+  }, [folders, iconColor, t])
 
   const recordIdsKey = records.map((r) => r.id).sort().join(',')
   const customFoldersListKey = Object.keys(
@@ -102,7 +113,9 @@ export const MoveFolderModalContentV2 = ({
   const atDestination =
     !!selectedId &&
     records.length > 0 &&
-    records.every((r) => r.folder === selectedId)
+    (selectedId === CHIP_ID_ALL
+      ? records.every((r) => !r.folder)
+      : records.every((r) => r.folder === selectedId))
 
   const isMoveDisabled = isLoading || !selectedId || atDestination
 
@@ -121,7 +134,11 @@ export const MoveFolderModalContentV2 = ({
 
   const handleMove = async () => {
     if (!selectedId || isMoveDisabled) return
-    await updateFolder(records.map((r) => r.id), selectedId)
+    if (selectedId === CHIP_ID_ALL) {
+      await updateRecords(records.map((r) => ({ ...r, folder: null })))
+    } else {
+      await updateFolder(records.map((r) => r.id), selectedId)
+    }
     onCompleted?.()
   }
 

--- a/src/containers/RecordDetails/RecordDetailsV2.tsx
+++ b/src/containers/RecordDetails/RecordDetailsV2.tsx
@@ -87,8 +87,8 @@ export const RecordDetailsV2 = () => {
   }
 
   useEffect(() => {
-    if (!record) handleCollapse()
-  }, [record])
+    if (routerData.recordId && !record) handleCollapse()
+  }, [record, routerData.recordId])
 
   if (!record) return null
 

--- a/src/containers/RecordListView/RecordListViewV2.tsx
+++ b/src/containers/RecordListView/RecordListViewV2.tsx
@@ -86,8 +86,9 @@ export const RecordListViewV2 = ({
         )
         return
       }
+      const isAlreadyOpen = routeData?.recordId === record.id
       navigate(currentPage, {
-        recordId: record.id,
+        recordId: isAlreadyOpen ? '' : record.id,
         recordType: routeData?.recordType
       })
     },
@@ -96,6 +97,7 @@ export const RecordListViewV2 = ({
       setSelectedRecords,
       navigate,
       currentPage,
+      routeData?.recordId,
       routeData?.recordType
     ]
   )

--- a/src/containers/Sidebar/SidebarV2.styles.ts
+++ b/src/containers/Sidebar/SidebarV2.styles.ts
@@ -78,7 +78,8 @@ export const createStyles = (colors: ThemeColors, isCollapsed: boolean) => ({
     minWidth: 0,
     overflow: 'hidden' as const,
     textOverflow: 'ellipsis' as const,
-    whiteSpace: 'nowrap' as const
+    whiteSpace: 'nowrap' as const,
+    color: colors.colorTextPrimary
   },
 
   chevron: {

--- a/src/containers/Sidebar/SidebarV2.tsx
+++ b/src/containers/Sidebar/SidebarV2.tsx
@@ -252,7 +252,7 @@ export const SidebarV2 = () => {
       <div style={styles.scrollContainer}>
         <div style={styles.scrollArea}>
         {isVaultSelectorOpen && (
-          <VaultSelector />
+          <VaultSelector onClose={() => setIsVaultSelectorOpen(false)} />
         )}
 
         {!isVaultSelectorOpen && (

--- a/src/containers/Sidebar/SidebarV2.tsx
+++ b/src/containers/Sidebar/SidebarV2.tsx
@@ -232,7 +232,7 @@ export const SidebarV2 = () => {
           >
             <div style={styles.vaultNameRow}>
               <div style={styles.vaultNameText}>
-                <Text variant="labelEmphasized" numberOfLines={1}>
+                <Text variant="labelEmphasized">
                   {vaultData?.name ?? t('Personal Vault')}
                 </Text>
               </div>

--- a/src/containers/Sidebar/VaultSelector/VaultSelector.tsx
+++ b/src/containers/Sidebar/VaultSelector/VaultSelector.tsx
@@ -37,7 +37,11 @@ import { DeleteVaultModalContent } from '../../Modal/DeleteVaultModalContent'
 import { ModifyVaultModalContent } from '../../Modal/ModifyVaultModalContent'
 import { useVaultSwitch } from '../../../hooks/useVaultSwitch'
 
-export const VaultSelector = () => {
+type VaultSelectorProps = {
+  onClose?: () => void
+}
+
+export const VaultSelector = ({ onClose }: VaultSelectorProps = {}) => {
   const { t } = useTranslation()
   const { theme } = useTheme()
   const styles = createStyles(theme.colors)
@@ -76,7 +80,10 @@ export const VaultSelector = () => {
     setModal(
       <CreateOrEditVaultModalContentV2
         onClose={closeModal}
-        onSuccess={closeModal}
+        onSuccess={() => {
+          closeModal()
+          onClose?.()
+        }}
       />
     )
   }
@@ -85,6 +92,7 @@ export const VaultSelector = () => {
     if (activeVault?.id !== vault.id) {
       void switchVault(vault)
     }
+    onClose?.()
   }
 
   const handleInvite = (vault: Vault) => {

--- a/src/pages/MainView/MainViewV2.tsx
+++ b/src/pages/MainView/MainViewV2.tsx
@@ -179,7 +179,13 @@ export const MainViewV2 = () => {
         />
       )}
 
-      {!hasRecords && !hasSearch && !isLoading && <EmptyCollectionViewV2 />}
+      {!hasRecords && !hasSearch && !isLoading && (
+        <EmptyCollectionViewV2
+          recordType={routerData?.recordType ?? 'all'}
+          selectedFolder={selectedFolder}
+          isFavoritesView={isFavoritesView}
+        />
+      )}
 
       {!hasRecords && hasSearch && !isLoading && <EmptyResultsViewV2 />}
     </div>


### PR DESCRIPTION
### Changes

- **Sidebar / Vault selector**
  - Truncate the selected vault name with an ellipsis when it doesn't fit the header.
  - Auto-close the vault dropdown after creating or selecting a vault.
- **Empty collection view**
  - Show contextual title and description for favorites, the active folder, or the active category (priority: favorites → folder → category → default). Favorites empty state has no CTA buttons.
- **Move to another folder modal**
  - Add an "All Items" chip that removes the selected records from any folder (uses `updateRecords` with `folder: null`).
  - Pre-select the chip the records currently sit at, so the move button starts disabled until a different destination is picked.
- **Record details panel**
  - Toggle the panel closed when re-clicking the already-open record.
  - Animate the panel open/close (flex-grow + border-left-width over 150ms) to match the sidebar collapse transition.
- **Delete folder modal**
  - Break each option's description onto a new line per sentence (via inherited `white-space: pre-line` + `\n`).
- **Build / i18n**
  - Attach the Lingui ICU runtime compiler so production builds interpolate placeholders like `{count}` instead of rendering them literally.

### Notes

Placeholder interpolation was tested using:

```
NODE_ENV=production npm run build:prod
npx electron .
```

### Screenshots/Recordings

https://github.com/user-attachments/assets/3ec4859c-3da7-4e15-a913-effb636ec6bc