### PR TITLE
Lower app size for users

### DIFF
--- a/electron-builder.linux.json
+++ b/electron-builder.linux.json
@@ -12,7 +12,9 @@
     "index.js",
     "packages/**/*",
     "assets/**/*",
-    "src/utils/**/*"
+    "src/utils/**/*",
+    "!**/node_modules/react-native/**/*",
+    "!**/node_modules/@react-native/**/*"
   ],
   "extraResources": [
     {

--- a/electron-builder.mac.json
+++ b/electron-builder.mac.json
@@ -12,7 +12,9 @@
     "index.js",
     "packages/**/*",
     "assets/**/*",
-    "src/utils/**/*"
+    "src/utils/**/*",
+    "!**/node_modules/react-native/**/*",
+    "!**/node_modules/@react-native/**/*"
   ],
   "extraResources": [
     {

--- a/forge.config.cjs
+++ b/forge.config.cjs
@@ -36,7 +36,6 @@ const packagerConfig = {
     // RN deps — bundled by esbuild, never required at runtime
     /(^|\/)node_modules\/react-native(\/|$)/,
     /(^|\/)node_modules\/@react-native(\/|$)/,
-    /^\/build($|\/)/,
     /^\/e2e($|\/)/,
     /^\/docs($|\/)/,
   ]

--- a/forge.config.cjs
+++ b/forge.config.cjs
@@ -31,7 +31,15 @@ function getWindowsKitVersion() {
 const packagerConfig = {
   icon: path.join(__dirname, 'assets', 'win32', 'icon'),
   protocols: [{ name: appName, schemes: [pkg.name] }],
-  derefSymlinks: true
+  derefSymlinks: true,
+  ignore: [
+    // RN deps — bundled by esbuild, never required at runtime
+    /(^|\/)node_modules\/react-native(\/|$)/,
+    /(^|\/)node_modules\/@react-native(\/|$)/,
+    /^\/build($|\/)/,
+    /^\/e2e($|\/)/,
+    /^\/docs($|\/)/,
+  ]
 }
 
 /** @type {import('@electron-forge/shared-types').ForgeConfig} */

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
-      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.3.tgz",
+      "integrity": "sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -241,7 +241,7 @@
         "@babel/helper-optimise-call-expression": "^7.27.1",
         "@babel/helper-replace-supers": "^7.28.6",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -468,9 +468,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -2083,9 +2083,9 @@
       }
     },
     "node_modules/@babel/register": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.28.6.tgz",
-      "integrity": "sha512-pgcbbEl/dWQYb6L6Yew6F94rdwygfuv+vJ/tXfwIOYAfPB6TNWpXUMEtEq3YuTeHRdvMIhvz13bkT9CNaS+wqA==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.29.3.tgz",
+      "integrity": "sha512-F6C1KpIdoImKQfsD6HSxZ+mS4YY/2Q+JsqrmTC5ApVkTR2rG+nnbpjhWwzA5bDNu8mJjB3AryqDaWFLd4gCbJQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5913,21 +5913,21 @@
       }
     },
     "node_modules/@rive-app/react-webgl2": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/@rive-app/react-webgl2/-/react-webgl2-4.28.2.tgz",
-      "integrity": "sha512-LbY10eCZiht8ik1fkton1lVTTakPtpPVYSZfHYjxWI07x3hw7OpEiETkQ8OcXhKGRTfjaPosZB5DvnWqWvaD/Q==",
+      "version": "4.28.3",
+      "resolved": "https://registry.npmjs.org/@rive-app/react-webgl2/-/react-webgl2-4.28.3.tgz",
+      "integrity": "sha512-vHMmrNDd2vxKNWy2z0Mfn28dN13yXLdEAlf0JGCdZTIXsf1XipvP7hYrEFsvdD/IleF236FxZCRkGRVpx/YJzg==",
       "license": "MIT",
       "dependencies": {
-        "@rive-app/webgl2": "2.37.4"
+        "@rive-app/webgl2": "2.37.5"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0"
       }
     },
     "node_modules/@rive-app/webgl2": {
-      "version": "2.37.4",
-      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.37.4.tgz",
-      "integrity": "sha512-7RPKURqHbwVGOBMwbyVosKMZ+6D2Idf3RXQz4hnEpG9xb9uRUVUw/+5AMADkOJ2qI+ZDwmBscGGkJEg3c4b4fw==",
+      "version": "2.37.5",
+      "resolved": "https://registry.npmjs.org/@rive-app/webgl2/-/webgl2-2.37.5.tgz",
+      "integrity": "sha512-HvzjvComnOh1pns/BIGbnrZglNxNov5yhmpWO2+i6jlrbV8uovgAWlNm4HTmt+X6eKDrnh8x6G236ABXIqoORQ==",
       "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
@@ -6178,7 +6178,7 @@
     "node_modules/@tetherto/pearpass-lib-constants": {
       "name": "pearpass-lib-constants",
       "version": "0.0.11",
-      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-constants.git#816cb9e33a8b90fe047ca0acb2382b3bfe83c176",
+      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-constants.git#66703b535578f6aeeefa9e1a3f0b3fe2947fcd2e",
       "license": "Apache-2.0"
     },
     "node_modules/@tetherto/pearpass-lib-data-export": {
@@ -6218,7 +6218,7 @@
     "node_modules/@tetherto/pearpass-lib-ui-kit": {
       "name": "pearpass-lib-ui-react-native-components",
       "version": "0.0.40",
-      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-ui-react-native-components.git#e2f2f7a594bee0b4e606e8b373022406bc36ef1a",
+      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-ui-react-native-components.git#91602818db615bf8b2f9a6482baaa407c06f96b0",
       "license": "Apache-2.0",
       "dependencies": {
         "react-strict-dom": "^0.0.55"
@@ -6232,6 +6232,26 @@
         "react-native-gesture-handler": "^2.24.0",
         "react-native-reanimated": "^3.17.4",
         "react-native-svg": "15.11.2"
+      },
+      "peerDependenciesMeta": {
+        "@gorhom/bottom-sheet": {
+          "optional": true
+        },
+        "@react-native-community/datetimepicker": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "react-native-gesture-handler": {
+          "optional": true
+        },
+        "react-native-reanimated": {
+          "optional": true
+        },
+        "react-native-svg": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tetherto/pearpass-lib-ui-theme-provider": {
@@ -6249,7 +6269,7 @@
     "node_modules/@tetherto/pearpass-lib-vault": {
       "name": "pearpass-lib-vault",
       "version": "0.0.85",
-      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-vault.git#1d4f8665e7af42f2a9c280d583efbbe5932bebf9",
+      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-vault.git#21d29ed5ba6c2c1272df6017389c0192f3178581",
       "license": "Apache-2.0",
       "dependencies": {
         "@reduxjs/toolkit": "2.5.0",
@@ -6263,9 +6283,10 @@
     "node_modules/@tetherto/pearpass-lib-vault-core": {
       "name": "pearpass-lib-vault-core",
       "version": "0.0.65",
-      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-vault-core.git#fb59aa9dc077ea89e0a3c48c4e1f18fa2ffbdd98",
+      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-vault-core.git#c5ccc0371f80003efc2049454b62cbad7521703f",
       "license": "Apache-2.0",
       "dependencies": {
+        "@tetherto/pearpass-utils-password-check": "git+https://github.com/tetherto/pearpass-utils-password-check",
         "autopass": "~3.3.0",
         "b4a": "^1.7.3",
         "bare-buffer": "^3.4.2",
@@ -6291,7 +6312,7 @@
         "udx-native": "^1.19.2"
       },
       "optionalDependencies": {
-        "@tetherto/swarmconf": "git+https://github.com/tetherto/tether-hp-conf-swarm.git"
+        "@tetherto/swarmconf": "^1.0.0"
       }
     },
     "node_modules/@tetherto/pearpass-lib-vault-core/node_modules/bare-fs": {
@@ -6330,16 +6351,6 @@
       "resolved": "git+ssh://git@github.com/tetherto/pearpass-utils-password-generator.git#66f9e8b0ce79bedadcb078876d24745d57a39c02",
       "license": "Apache-2.0"
     },
-    "node_modules/@tetherto/swarmconf": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/tetherto/tether-hp-conf-swarm.git#198a5c88ee768f3d4d691a993ec76b1edf6d7ace",
-      "license": "UNLICENSED",
-      "optional": true,
-      "dependencies": {
-        "hyperconf": "^1.0.2",
-        "hyperschema": "^1.17.0"
-      }
-    },
     "node_modules/@tetherto/tether-dev-docs": {
       "name": "tether-dev-docs",
       "version": "0.0.8",
@@ -6348,9 +6359,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7712,9 +7723,9 @@
       }
     },
     "node_modules/app-builder-lib/node_modules/node-abi": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.28.0.tgz",
-      "integrity": "sha512-Qfp5XZL1cJDOabOT8H5gnqMTmM4NjvYzHp4I/Kt/Sl76OVkOBBHRFlPspGV0hYvMoqQsypFjT/Yp7Km0beXW9g==",
+      "version": "4.29.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.29.0.tgz",
+      "integrity": "sha512-bGc7hHz6lrdpMqH3XqfiHc5PKzEhjgUj6OLpTXynkLi9JZKyMByI/tdpm4Liu6O2BjtE1lakBWXjOQS1EnSQLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8190,21 +8201,21 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/b4a": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
-      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -8518,9 +8529,9 @@
       }
     },
     "node_modules/bare-crypto": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/bare-crypto/-/bare-crypto-1.13.4.tgz",
-      "integrity": "sha512-JiCZ5l2YOG1y8J7yy1BCAKTCZrPnHLb7pDRIdurBTOn5oIwBQDIv8iH5Pl2V85vzjl1NZXRfNY4HZLsE942jJA==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/bare-crypto/-/bare-crypto-1.13.5.tgz",
+      "integrity": "sha512-+QOwpHo4kCGRE3itG/hUrKpNOvDFSC+olSh3ARCgQV9Vh0LMpecFyl+t0+Cdfrw7oWbw+O/kqF/IGGqVCysl4g==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-assert": "^1.2.0",
@@ -8579,14 +8590,14 @@
       }
     },
     "node_modules/bare-fetch": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/bare-fetch/-/bare-fetch-2.9.0.tgz",
-      "integrity": "sha512-DfqPMmdPOCxPFzkVTpyYMR4jaEO9rD/POE7Py5iJhPJmJsVNB1LQDBpK03H3CGcAp52r4hngeYItQfOxldBRRQ==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-fetch/-/bare-fetch-2.9.1.tgz",
+      "integrity": "sha512-OqyubfnEXu9BqIVXg+LcdsutZk+amvPey2N+FeG7zeIk+0qarDreAMtixcRGvpR95rM1SNJedHRpBv3BNjja5g==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-form-data": "^1.2.0",
         "bare-http1": "^4.5.2",
-        "bare-https": "^2.0.0",
+        "bare-https": "^3.0.0",
         "bare-mime": "^1.0.0",
         "bare-stream": "^2.9.1",
         "bare-url": "^2.4.0",
@@ -8685,14 +8696,14 @@
       }
     },
     "node_modules/bare-https": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/bare-https/-/bare-https-2.1.3.tgz",
-      "integrity": "sha512-0TI/mJXQGYXmG7UUyWEG+KCJusayIAQLywUjFAskDoKuxfqVnGF+M/mTMrEV8J64DaIdU+5x761FvgmT7M68tA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-https/-/bare-https-3.0.0.tgz",
+      "integrity": "sha512-W1GRSCzn+xXKf5bMcPs/hg6Ga1bxPqb7owGfS+tvlBQfPe5Q2STcanRuKZrgU60v5uKrhXH5cgWwM+DLqvXZgQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-http1": "^4.4.0",
         "bare-tcp": "^2.2.0",
-        "bare-tls": "^2.0.0"
+        "bare-tls": "^3.0.0"
       }
     },
     "node_modules/bare-inspect": {
@@ -8756,9 +8767,9 @@
       }
     },
     "node_modules/bare-module-resolve": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.1.tgz",
-      "integrity": "sha512-hbmAPyFpEq8FoZMd5sFO3u6MC5feluWoGE8YKlA8fCrl6mNtx68Wjg4DTiDJcqRJaovTvOYKfYngoBUnbaT7eg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.2.tgz",
+      "integrity": "sha512-j+hiD5k99qec4KjJvYsI67q5AOBifmy9JG3oeMVxTmvrhn2sIdp8StrUvZu4YNgwTpO+NhniQG16N1ETDe1k5w==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-semver": "^1.0.0"
@@ -8887,9 +8898,9 @@
       }
     },
     "node_modules/bare-process/node_modules/bare-os": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.0.tgz",
-      "integrity": "sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
       "license": "Apache-2.0",
       "engines": {
         "bare": ">=1.14.0"
@@ -8906,9 +8917,9 @@
       }
     },
     "node_modules/bare-rpc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/bare-rpc/-/bare-rpc-1.2.0.tgz",
-      "integrity": "sha512-BFuBGs8scK9yAOPQxaNkz4DxD7dRg4O6GOVH5lg+H+vJAAjfxHGDfx3Kd9KzdAfeSBVc1F+ICbdMxRa7yn/qFQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bare-rpc/-/bare-rpc-1.3.0.tgz",
+      "integrity": "sha512-4WYP38LGyB6qJR0TozEVEuP3nh56yCzVcmitmFqxIkLyHNEpuISHeUgWejuzhm+56a/hTZ563upaBqNJh/5KPQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.6",
@@ -9085,9 +9096,9 @@
       }
     },
     "node_modules/bare-tls": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/bare-tls/-/bare-tls-2.2.3.tgz",
-      "integrity": "sha512-dPYBGEXtgLceRFMfGaF2/rqR86/xMxMyrM9ootO/gaRKL/z2uNHJs7aP7IOBtnJF8eUCt5qwMzbKfrKgDIxPLg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-tls/-/bare-tls-3.1.1.tgz",
+      "integrity": "sha512-UKlGyVQNJscSppMfFVhtZlZxTSSG7sSe/uEmMFURb/0sKVPadVZ74Bqocj0qtRCvRAmpD4vfqtTBCn/ryDmjGA==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-net": "^2.0.1",
@@ -9159,9 +9170,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.23",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
-      "integrity": "sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==",
+      "version": "2.10.27",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -9331,9 +9342,9 @@
       }
     },
     "node_modules/blind-peer-encodings/node_modules/hyperdb": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/hyperdb/-/hyperdb-6.6.1.tgz",
-      "integrity": "sha512-zQb3idlVQHopwbz8PxgusNGAUJwMFV9py7jhg1FC78iClOHDkeqWle9SB+n2VJkBDRpPzqQkehtABMRqBuh2+g==",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/hyperdb/-/hyperdb-6.6.3.tgz",
+      "integrity": "sha512-06GWodc4vADVgBytorN8ZbSQuB126+dFmt2WuBgdtRZpzi8H9VkMvapizqIdJe/1SlLfkiwDaJZpZSldXH/Igw==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.6",
@@ -9341,7 +9352,7 @@
         "generate-object-property": "^2.0.0",
         "generate-string": "^1.0.1",
         "hyperbee": "^2.24.2",
-        "hypercore": "^11.26.0",
+        "hypercore": "^11.29.0",
         "hyperschema": "^1.9.2",
         "index-encoder": "^3.4.0",
         "refcounter": "^1.0.0",
@@ -11366,9 +11377,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.344",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
-      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "version": "1.5.349",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
+      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
       "license": "ISC"
     },
     "node_modules/electron-updater": {
@@ -13069,9 +13080,9 @@
       "optional": true
     },
     "node_modules/flow-parser": {
-      "version": "0.311.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.311.0.tgz",
-      "integrity": "sha512-3tbmV0VdoFXdNqJjNksVLIksu78BvUMK5eAR5ZF1TAsV+wVu4jXipRpHKquDGhPRKrLl2DCafjRTV99jVMlMwQ==",
+      "version": "0.312.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.312.0.tgz",
+      "integrity": "sha512-y1iG1bU7i22Mc3sSlchhmV992o8vxzwFLy6K1ZZqbmfXf0qpljN1/AZRuhOA+8uMz8a5iQUdoUyT7pvmdN1flA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -13953,24 +13964,10 @@
         "streamx": "^2.13.2"
       }
     },
-    "node_modules/hyperconf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hyperconf/-/hyperconf-1.0.3.tgz",
-      "integrity": "sha512-Vd6Wex26I7BOXr2AciRtGU+Vbrc3Kx+VSOvy1H/TA8NBUkyitLG3S7AqbDVzscAVFlUrZynk/6SM+6Q6gxKe3w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "b4a": "^1.7.2",
-        "bare-fs": "^4.4.4",
-        "bare-path": "^3.0.0",
-        "hyperschema": "^1.15.0",
-        "ready-resource": "^1.2.0"
-      }
-    },
     "node_modules/hypercore": {
-      "version": "11.28.1",
-      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-11.28.1.tgz",
-      "integrity": "sha512-d8jqUilG7Gri8wT+sRdkFTYRPMHGyvBz/NCYHf5rX7+LoivRNRxQm5nWChT7caiUKbcsDak6h7IiEQ5wbD1wCg==",
+      "version": "11.29.0",
+      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-11.29.0.tgz",
+      "integrity": "sha512-tRF/CL/KOP5GJBEQfN8EjJbfG3ScFybJ3zH1aRAgQF42NBdL2S9wzu20d84HMauKFU92tYyGqKdAPD1eAW4Twg==",
       "license": "MIT",
       "dependencies": {
         "@hyperswarm/secret-stream": "^6.0.0",
@@ -14067,9 +14064,9 @@
       }
     },
     "node_modules/hyperdht": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/hyperdht/-/hyperdht-6.30.0.tgz",
-      "integrity": "sha512-LkfeAFVnOIvOpr2ILtJ38CzPgXmye7jXDS12xndVKfNoxzIrM0GonY+Bz5lHutoc08ZbT3Olr/w2NSeq5Pj0Ng==",
+      "version": "6.31.0",
+      "resolved": "https://registry.npmjs.org/hyperdht/-/hyperdht-6.31.0.tgz",
+      "integrity": "sha512-FIAZGOpYcbRqnWgfPfBbXs/7J6rjDfJqHh9AQWFmmsKkBmwGn/m2kreIKD4ZMIOaWbM5YTwj7aHvBw/CMHYg0Q==",
       "license": "MIT",
       "dependencies": {
         "@hyperswarm/secret-stream": "^6.6.2",
@@ -14492,9 +14489,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
-      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -18189,9 +18186,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -18244,9 +18241,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "version": "3.90.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.90.0.tgz",
+      "integrity": "sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -24615,9 +24612,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.0.tgz",
-      "integrity": "sha512-gHwIe1cgBvvfLeu1Yz/dcFpmHfKDVxxyqI+kzqmuxZED81z2ChxpyqPaWcNqigPywhaEke7AjSGga+kxY55gjQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.1.tgz",
+      "integrity": "sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -24964,9 +24961,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/scripts/afterPack.cjs
+++ b/scripts/afterPack.cjs
@@ -1,21 +1,151 @@
 #!/usr/bin/env node
 /**
- * Electron-builder afterPack hook for Linux:
+ * Electron-builder afterPack hook.
  *
- * 1. Remove chrome-sandbox — squashfs (AppImage) cannot preserve SUID bits,
- *    so Chromium's setuid sandbox probe crashes before Node.js even starts.
+ * 1. Prune native `prebuilds/<platform>-<arch>` dirs that don't match the
+ *    current target. Native modules in the bare/holepunch ecosystem ship
+ *    prebuilds for every platform (darwin/linux/win32/android/ios × x64/arm64
+ *    + simulators).
  *
- * 2. Wrap the real Electron binary with a shell script that passes --no-sandbox.
- *    app.commandLine.appendSwitch('no-sandbox') in main.cjs is too late —
- *    Chromium's zygote sandbox decision happens before Node.js initializes.
- *    The wrapper ensures --no-sandbox reaches Chromium at process start.
+ * 2. Linux only: remove chrome-sandbox (squashfs/AppImage cannot preserve
+ *    SUID bits, so Chromium's setuid sandbox probe crashes before Node.js
+ *    even starts) and wrap the real Electron binary with a shell script that
+ *    passes --no-sandbox. app.commandLine.appendSwitch('no-sandbox') in
+ *    main.cjs is too late — Chromium's zygote sandbox decision happens
+ *    before Node.js initializes. The wrapper ensures --no-sandbox reaches
+ *    Chromium at process start.
  */
 const fs = require('fs')
+const fsp = require('fs/promises')
 const path = require('path')
 
-exports.default = async function afterPack(context) {
-  if (context.electronPlatformName !== 'linux') return
+const ARCH_NAMES = {
+  0: 'ia32',
+  1: 'x64',
+  2: 'armv7l',
+  3: 'arm64',
+  4: 'universal'
+}
 
+exports.default = async function afterPack(context) {
+  await prunePrebuilds(context)
+
+  if (context.electronPlatformName === 'linux') {
+    await wrapLinuxNoSandbox(context)
+  }
+}
+
+async function prunePrebuilds(context) {
+  const { appOutDir, electronPlatformName, arch, packager } = context
+  const archName = ARCH_NAMES[arch] ?? String(arch)
+  const target = `${electronPlatformName}-${archName}`
+
+  let appRoot
+  if (electronPlatformName === 'darwin' || electronPlatformName === 'mas') {
+    const appName = packager.appInfo.productFilename
+    appRoot = path.join(
+      appOutDir,
+      `${appName}.app`,
+      'Contents',
+      'Resources',
+      'app'
+    )
+  } else {
+    appRoot = path.join(appOutDir, 'resources', 'app')
+  }
+
+  const nodeModules = path.join(appRoot, 'node_modules')
+  if (!fs.existsSync(nodeModules)) {
+    console.warn(
+      `afterPack: node_modules not found at ${nodeModules}, skipping prune`
+    )
+    return
+  }
+
+  const stats = { kept: 0, removed: 0, bytes: 0 }
+  await pruneTree(appRoot, target, stats)
+
+  const mb = (stats.bytes / (1024 * 1024)).toFixed(1)
+  console.log(
+    `afterPack: pruned ${stats.removed} prebuild dir(s), kept ${stats.kept} ` +
+      `matching '${target}'/-universal, freed ~${mb} MB`
+  )
+}
+
+async function pruneTree(base, target, stats) {
+  await pruneOneLevel(path.join(base, 'prebuilds'), target, stats)
+
+  const nm = path.join(base, 'node_modules')
+  const entries = await safeReadDir(nm)
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.isDirectory()) return
+      const full = path.join(nm, entry.name)
+      if (entry.name.startsWith('@')) {
+        const subs = await safeReadDir(full)
+        await Promise.all(
+          subs.map((sub) =>
+            sub.isDirectory()
+              ? pruneTree(path.join(full, sub.name), target, stats)
+              : null
+          )
+        )
+      } else {
+        await pruneTree(full, target, stats)
+      }
+    })
+  )
+}
+
+async function pruneOneLevel(dir, target, stats) {
+  const entries = await safeReadDir(dir)
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    if (entry.name === target || entry.name.endsWith('-universal')) {
+      stats.kept++
+      continue
+    }
+    const full = path.join(dir, entry.name)
+    stats.bytes += await dirSize(full)
+    await fsp.rm(full, { recursive: true, force: true })
+    stats.removed++
+  }
+}
+
+async function safeReadDir(dir) {
+  try {
+    return await fsp.readdir(dir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+}
+
+async function dirSize(dir) {
+  let total = 0
+  const stack = [dir]
+  while (stack.length) {
+    const d = stack.pop()
+    let entries
+    try {
+      entries = await fsp.readdir(d, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const e of entries) {
+      const full = path.join(d, e.name)
+      try {
+        if (e.isDirectory()) stack.push(full)
+        else {
+          const s = await fsp.stat(full)
+          total += (s.blocks ?? 0) * 512 || s.size
+        }
+      } catch {}
+    }
+  }
+  return total
+}
+
+async function wrapLinuxNoSandbox(context) {
   const appOutDir = context.appOutDir
 
   // 1. Remove chrome-sandbox (cannot work inside squashfs / AppImage)


### PR DESCRIPTION
### Changes

- Get rid of unneeded prebuild folders from holepunch side. Libs like bare-sidecar, rocksdb-native, bare-tls ship /prebuilds with binaries for every platform (darwin/linux/win32/android/ios × x64/arm64). In afterPack we walk the bundled node_modules and keep only the dirs matching the build target.
- Get rid of react native deps


Analytics on my mac arm:

Initial	                        1.1 GB (/out folder)	336 MB (dmg)
Prebuild prune only	580 MB	                        178 MB
Both	                        478 MB                             171 MB

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213987034629408