### PR TITLE
Add note field for other item type

### DIFF
--- a/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditCustomModalContentV2/CreateOrEditCustomModalContentV2.tsx
+++ b/src/containers/Modal/CreateOrEditCategoryWrapper/CreateOrEditCustomModalContentV2/CreateOrEditCustomModalContentV2.tsx
@@ -38,6 +38,7 @@ export type CreateOrEditCustomModalContentV2Props = {
   initialRecord?: {
     data: {
       title: string
+      note?: string
       customFields: { type: string; name?: string; note?: string }[]
       attachments: { id: string; name: string }[]
       [key: string]: unknown
@@ -87,6 +88,7 @@ export const CreateOrEditCustomModalContentV2 = ({
 
   const schema = Validator.object({
     title: Validator.string().required(t('Title is required')),
+    note: Validator.string(),
     customFields: Validator.array().items(
       Validator.object({
         note: Validator.string()
@@ -104,6 +106,7 @@ export const CreateOrEditCustomModalContentV2 = ({
   const { register, handleSubmit, registerArray, values, setValue } = useForm({
     initialValues: {
       title: initialRecord?.data?.title ?? '',
+      note: initialRecord?.data?.note ?? '',
       customFields: initialRecord?.data?.customFields?.length
         ? initialRecord.data.customFields
         : [{ type: 'note', name: 'note', note: '' }],
@@ -135,6 +138,7 @@ export const CreateOrEditCustomModalContentV2 = ({
       data: {
         ...(initialRecord?.data ? initialRecord.data : {}),
         title: formValues.title,
+        note: formValues.note,
         customFields: (
           (formValues.customFields as Array<{ type: string; note?: string }>) ??
           []
@@ -168,6 +172,7 @@ export const CreateOrEditCustomModalContentV2 = ({
   const isEdit = !!initialRecord
 
   const titleField = register('title')
+  const noteField = register('note')
 
   return (
     <Dialog
@@ -226,6 +231,17 @@ export const CreateOrEditCustomModalContentV2 = ({
             setValue('folder', name === values.folder ? '' : name)
           }
         />
+
+        <MultiSlotInput testID="createoredit-custom-comments-slot-v2">
+          <InputField
+            label={t('Comment')}
+            placeholder={t('Enter Comment')}
+            value={noteField.value}
+            onChange={(e) => noteField.onChange(e.target.value)}
+            error={noteField.error || undefined}
+            testID="createoredit-custom-input-comment-v2"
+          />
+        </MultiSlotInput>
 
         <MultiSlotInput
           testID="createoredit-custom-attachments-slot-v2"

--- a/src/containers/RecordDetails/CustomDetailsForm/CustomDetailsFormV2.tsx
+++ b/src/containers/RecordDetails/CustomDetailsForm/CustomDetailsFormV2.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo } from 'react'
 import { useForm } from '@tetherto/pear-apps-lib-ui-react-hooks'
 import {
   AttachmentField,
+  InputField,
   MultiSlotInput,
   PasswordField,
   Text,
@@ -37,6 +38,7 @@ type CustomRecord = {
   attachments?: Attachment[]
   data: {
     title?: string
+    note?: string
     customFields?: CustomField[]
   }
 }
@@ -47,6 +49,7 @@ type CustomDetailsFormV2Props = {
 }
 
 type CustomDetailsFormValues = {
+  note: string
   customFields: CustomField[]
   folder?: string
   attachments: Attachment[]
@@ -69,6 +72,7 @@ export const CustomDetailsFormV2 = ({
 
   const initialValues = useMemo<CustomDetailsFormValues>(
     () => ({
+      note: initialRecord?.data?.note ?? '',
       customFields: initialRecord?.data?.customFields ?? [],
       folder: selectedFolder ?? initialRecord?.folder,
       attachments: initialRecord?.attachments ?? []
@@ -90,6 +94,7 @@ export const CustomDetailsFormV2 = ({
 
   const hasCustomFields = !!values.customFields?.length
   const hasAttachments = !!values.attachments?.length
+  const hasNote = !!(values.note as string)?.length
 
   const handleAttachmentPress = (attachment: Attachment) => {
     if (!attachment?.buffer || !attachment?.name) return
@@ -119,11 +124,26 @@ export const CustomDetailsFormV2 = ({
 
   return (
     <div style={styles.container}>
-      {(hasAttachments || hasCustomFields) && (
+      {(hasAttachments || hasCustomFields || hasNote) && (
         <div style={styles.section}>
           <Text variant="caption" color={theme.colors.colorTextSecondary}>
             {t('Additional')}
           </Text>
+
+          {hasNote && (
+            <MultiSlotInput testID="comments-multi-slot-input">
+              <InputField
+                label={t('Comment')}
+                value={(values.note as string) ?? ''}
+                placeholder={t('Enter Comment')}
+                readOnly
+                copyable
+                onCopy={copyToClipboard}
+                isGrouped
+                testID="comments-multi-slot-input-slot-0"
+              />
+            </MultiSlotInput>
+          )}
 
           {hasAttachments && (
             <MultiSlotInput testID="attachments-multi-slot-input">


### PR DESCRIPTION
### Changes

Add note field for other item type

### Screenshots/Recordings

<img width="1446" height="871" alt="Screenshot 2026-05-05 at 16 20 01" src="https://github.com/user-attachments/assets/99b43f07-07bd-4dce-a7b2-5aaaf14c216f" />
<img width="1443" height="862" alt="Screenshot 2026-05-05 at 16 20 14" src="https://github.com/user-attachments/assets/cc2644c8-827e-49a3-846c-2a9895712900" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214500598434227