### PR TITLE
Rewrite native host wrapper on each launch to fix AppImage stale paths.

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -5,6 +5,7 @@
  * and registers secure IPC handlers so the renderer can use runtime and vault services.
  */
 const fs = require('fs')
+const os = require('os')
 const path = require('path')
 
 const {
@@ -38,6 +39,7 @@ const {
   isFlatpakRuntime,
   isSnapRuntime
 } = require('./flatpak-paths.cjs')
+const { refreshNativeHostWrapperIfPresent } = require('./nativeHostWrapper.cjs')
 const runtimeConfig = require('./runtime-config.cjs')
 const devicePreferences = require('../src/utils/devicePreferences.cjs')
 const {
@@ -193,6 +195,55 @@ function getNativeBridgePath() {
   }
 
   return path.join(app.getAppPath(), bundleFile)
+}
+
+function getRuntimeExecPath() {
+  return isWindows && process.windowsStore
+    ? path.join(
+        process.env.LOCALAPPDATA,
+        'Microsoft',
+        'WindowsApps',
+        path.basename(process.execPath)
+      )
+    : process.execPath
+}
+
+// AppImage mounts at a fresh /tmp/.mount_PearPa<random>/ each launch, so the
+// execPath/bridgePath baked into the wrapper at pair time go stale. Rewrite.
+async function refreshNativeHostWrapper() {
+  // Snap mounts the app at a stable path, so wrapper paths don't drift.
+  if (isSnapRuntime()) return
+
+  const platform = os.platform()
+  const executablePath = path.join(
+    getStorageDir(),
+    'native-messaging',
+    platform === 'win32'
+      ? 'pearpass-native-host.cmd'
+      : 'pearpass-native-host.sh'
+  )
+
+  try {
+    const result = await refreshNativeHostWrapperIfPresent({
+      executablePath,
+      electronExecPath: getRuntimeExecPath(),
+      bridgeScriptPath: getNativeBridgePath(),
+      platform,
+      isFlatpak: isFlatpakRuntime()
+    })
+    if (result.refreshed) {
+      logger.info(
+        '[MAIN]',
+        `Refreshed native messaging wrapper at ${executablePath}`
+      )
+    }
+  } catch (err) {
+    logger.warn(
+      '[MAIN]',
+      'Failed to refresh native messaging wrapper:',
+      (err && err.message) || err
+    )
+  }
 }
 
 /**
@@ -595,15 +646,7 @@ function registerIPC() {
       productName: runtimeConfig.productName,
       applink: runtimeConfig.upgrade || '',
       userDataPath: getStorageDir(),
-      execPath:
-        isWindows && process.windowsStore
-          ? path.join(
-              process.env.LOCALAPPDATA,
-              'Microsoft',
-              'WindowsApps',
-              path.basename(process.execPath)
-            )
-          : process.execPath,
+      execPath: getRuntimeExecPath(),
       bridgePath: getNativeBridgePath()
     }
   })
@@ -734,6 +777,7 @@ app.whenReady().then(async () => {
     logger.setLogPath(getStorageDir())
   }
   registerIPC()
+  await refreshNativeHostWrapper()
   try {
     await startRuntime()
   } catch (err) {

--- a/electron/nativeHostWrapper.cjs
+++ b/electron/nativeHostWrapper.cjs
@@ -1,0 +1,101 @@
+const fsp = require('fs/promises')
+
+const FLATPAK_APP_ID = 'com.pears.pass'
+const FLATPAK_NATIVE_HOST_COMMAND = 'pearpass-native-host'
+
+// Wrappers emit diagnostics to stderr only: Chrome reads stdout as framed
+// native-messaging payloads, so any plain text there drops the port with
+// "Native host has exited".
+function buildWrapperContent({
+  platform,
+  isFlatpak,
+  electronExecPath,
+  bridgeScriptPath
+}) {
+  if (platform === 'linux' && isFlatpak) {
+    // Chrome runs outside the flatpak sandbox; the wrapper re-enters via
+    // `flatpak run` so the in-sandbox /app/* paths resolve correctly.
+    return `#!/bin/bash
+# PearPass Native Messaging Host (flatpak)
+# Chrome launches this on the host; re-enter the sandbox to run the bridge.
+set -u
+
+FLATPAK_BIN="$(command -v flatpak 2>/dev/null || true)"
+if [ -z "\${FLATPAK_BIN}" ]; then
+  for candidate in /usr/bin/flatpak /usr/local/bin/flatpak /var/lib/flatpak/exports/bin/flatpak; do
+    if [ -x "\${candidate}" ]; then
+      FLATPAK_BIN="\${candidate}"
+      break
+    fi
+  done
+fi
+if [ -z "\${FLATPAK_BIN}" ]; then
+  echo "pearpass-native-host: flatpak binary not found on PATH" >&2
+  exit 127
+fi
+
+exec "\${FLATPAK_BIN}" run --command=${FLATPAK_NATIVE_HOST_COMMAND} ${FLATPAK_APP_ID} "$@"
+`
+  }
+
+  if (platform === 'darwin' || platform === 'linux') {
+    return `#!/bin/bash
+# PearPass Native Messaging Host
+# Runs the native messaging bridge via Electron's embedded Node.js
+
+export ELECTRON_RUN_AS_NODE=1
+exec "${electronExecPath}" "${bridgeScriptPath}"
+`
+  }
+
+  if (platform === 'win32') {
+    return `@echo off
+REM PearPass Native Messaging Host
+REM Runs the native messaging bridge via Electron's embedded Node.js
+
+set ELECTRON_RUN_AS_NODE=1
+"${electronExecPath}" "${bridgeScriptPath}"
+`
+  }
+
+  throw new Error(`Unsupported platform: ${platform}`)
+}
+
+// Atomic so Chrome can't read a half-written wrapper while spawning the host.
+async function writeWrapperAtomic(executablePath, content, platform) {
+  const tmpPath = `${executablePath}.tmp-${process.pid}`
+  await fsp.writeFile(tmpPath, content, 'utf8')
+  if (platform !== 'win32') {
+    await fsp.chmod(tmpPath, 0o755)
+  }
+  await fsp.rename(tmpPath, executablePath)
+}
+
+async function refreshNativeHostWrapperIfPresent({
+  executablePath,
+  electronExecPath,
+  bridgeScriptPath,
+  platform,
+  isFlatpak
+}) {
+  try {
+    await fsp.access(executablePath)
+  } catch {
+    return { refreshed: false, reason: 'not-present' }
+  }
+
+  const content = buildWrapperContent({
+    platform,
+    isFlatpak,
+    electronExecPath,
+    bridgeScriptPath
+  })
+  await writeWrapperAtomic(executablePath, content, platform)
+  return { refreshed: true }
+}
+
+module.exports = {
+  buildWrapperContent,
+  writeWrapperAtomic,
+  refreshNativeHostWrapperIfPresent
+}

--- a/electron/nativeHostWrapper.test.js
+++ b/electron/nativeHostWrapper.test.js
@@ -1,0 +1,137 @@
+/* eslint-env jest */
+
+jest.mock('fs/promises', () => ({
+  access: jest.fn(),
+  writeFile: jest.fn(),
+  chmod: jest.fn(),
+  rename: jest.fn()
+}))
+
+const fsp = require('fs/promises')
+
+const {
+  buildWrapperContent,
+  writeWrapperAtomic,
+  refreshNativeHostWrapperIfPresent
+} = require('./nativeHostWrapper.cjs')
+
+const EXEC_PATH = '/mock/electron/PearPass'
+const BRIDGE_PATH = '/mock/dist/native-messaging-bridge.bundle.cjs'
+const WRAPPER_PATH = '/mock/userData/native-messaging/pearpass-native-host.sh'
+
+describe('buildWrapperContent', () => {
+  it('emits a bash wrapper with ELECTRON_RUN_AS_NODE for darwin', () => {
+    const content = buildWrapperContent({
+      platform: 'darwin',
+      isFlatpak: false,
+      electronExecPath: EXEC_PATH,
+      bridgeScriptPath: BRIDGE_PATH
+    })
+    expect(content).toContain('#!/bin/bash')
+    expect(content).toContain('ELECTRON_RUN_AS_NODE=1')
+    expect(content).toContain(EXEC_PATH)
+    expect(content).toContain(BRIDGE_PATH)
+  })
+
+  it('emits a bash wrapper with ELECTRON_RUN_AS_NODE for linux', () => {
+    const content = buildWrapperContent({
+      platform: 'linux',
+      isFlatpak: false,
+      electronExecPath: EXEC_PATH,
+      bridgeScriptPath: BRIDGE_PATH
+    })
+    expect(content).toContain('#!/bin/bash')
+    expect(content).toContain('ELECTRON_RUN_AS_NODE=1')
+    expect(content).toContain(EXEC_PATH)
+  })
+
+  it('emits a flatpak re-entry wrapper when isFlatpak is true', () => {
+    const content = buildWrapperContent({
+      platform: 'linux',
+      isFlatpak: true,
+      electronExecPath: EXEC_PATH,
+      bridgeScriptPath: BRIDGE_PATH
+    })
+    expect(content).toContain('flatpak')
+    expect(content).toContain('com.pears.pass')
+    expect(content).toContain('--command=pearpass-native-host')
+    // In-sandbox paths are resolved by `flatpak run`, not baked into the wrapper.
+    expect(content).not.toContain(EXEC_PATH)
+    expect(content).not.toContain(BRIDGE_PATH)
+  })
+
+  it('emits a cmd wrapper for win32', () => {
+    const content = buildWrapperContent({
+      platform: 'win32',
+      isFlatpak: false,
+      electronExecPath: EXEC_PATH,
+      bridgeScriptPath: BRIDGE_PATH
+    })
+    expect(content).toContain('@echo off')
+    expect(content).toContain('set ELECTRON_RUN_AS_NODE=1')
+    expect(content).toContain(EXEC_PATH)
+  })
+
+  it('throws on unsupported platforms', () => {
+    expect(() =>
+      buildWrapperContent({
+        platform: 'aix',
+        isFlatpak: false,
+        electronExecPath: EXEC_PATH,
+        bridgeScriptPath: BRIDGE_PATH
+      })
+    ).toThrow('Unsupported platform: aix')
+  })
+})
+
+describe('writeWrapperAtomic', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('writes to a tmp path, chmods, then renames into place on unix', async () => {
+    await writeWrapperAtomic(WRAPPER_PATH, 'content', 'linux')
+    const tmpPath = fsp.writeFile.mock.calls[0][0]
+    expect(tmpPath.startsWith(`${WRAPPER_PATH}.tmp-`)).toBe(true)
+    expect(fsp.chmod).toHaveBeenCalledWith(tmpPath, 0o755)
+    expect(fsp.rename).toHaveBeenCalledWith(tmpPath, WRAPPER_PATH)
+  })
+
+  it('skips chmod on win32', async () => {
+    await writeWrapperAtomic(WRAPPER_PATH, 'content', 'win32')
+    expect(fsp.chmod).not.toHaveBeenCalled()
+    expect(fsp.rename).toHaveBeenCalled()
+  })
+})
+
+describe('refreshNativeHostWrapperIfPresent', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns not-present and does not write when wrapper is absent', async () => {
+    fsp.access.mockRejectedValueOnce(new Error('ENOENT'))
+    const result = await refreshNativeHostWrapperIfPresent({
+      executablePath: WRAPPER_PATH,
+      electronExecPath: EXEC_PATH,
+      bridgeScriptPath: BRIDGE_PATH,
+      platform: 'linux',
+      isFlatpak: false
+    })
+    expect(result).toEqual({ refreshed: false, reason: 'not-present' })
+    expect(fsp.writeFile).not.toHaveBeenCalled()
+    expect(fsp.rename).not.toHaveBeenCalled()
+  })
+
+  it('rewrites atomically when wrapper exists', async () => {
+    fsp.access.mockResolvedValueOnce()
+    const result = await refreshNativeHostWrapperIfPresent({
+      executablePath: WRAPPER_PATH,
+      electronExecPath: EXEC_PATH,
+      bridgeScriptPath: BRIDGE_PATH,
+      platform: 'linux',
+      isFlatpak: false
+    })
+    expect(result).toEqual({ refreshed: true })
+    const writeCall = fsp.writeFile.mock.calls[0]
+    expect(writeCall[0].startsWith(`${WRAPPER_PATH}.tmp-`)).toBe(true)
+    expect(writeCall[1]).toContain(EXEC_PATH)
+    expect(fsp.rename).toHaveBeenCalledWith(writeCall[0], WRAPPER_PATH)
+  })
+})

--- a/src/utils/nativeMessagingSetup.js
+++ b/src/utils/nativeMessagingSetup.js
@@ -12,12 +12,11 @@ import {
 
 import { logger } from './logger'
 import flatpakPaths from '../../electron/flatpak-paths.cjs'
+import nativeHostWrapper from '../../electron/nativeHostWrapper.cjs'
 
 const { isFlatpakRuntime, isSnapRuntime, getHostHome, getSnapRealHome } =
   flatpakPaths
-
-const FLATPAK_APP_ID = 'com.pears.pass'
-const FLATPAK_NATIVE_HOST_COMMAND = 'pearpass-native-host'
+const { buildWrapperContent } = nativeHostWrapper
 
 const NATIVE_BRIDGE_PROCESS_IDENTIFIER = 'pearpass-lib-native-messaging-bridge'
 
@@ -78,57 +77,12 @@ export const generateNativeHostExecutable = async (
 ) => {
   try {
     const platform = os.platform()
-    let content
-
-    if (platform === 'linux' && isFlatpakRuntime()) {
-      // Chrome runs outside the flatpak sandbox, so the wrapper must
-      // re-enter the sandbox via `flatpak run` before execing the bridge.
-      // The /app/* electronExecPath and bridgeScriptPath are only valid
-      // inside the sandbox and are resolved by the in-sandbox command.
-      //
-      // Diagnostics MUST go to stderr: Chrome's native-messaging protocol
-      // treats anything on stdout as a framed message and will drop the port
-      // ("Native host has exited") if we write plain text there.
-      content = `#!/bin/bash
-# PearPass Native Messaging Host (flatpak)
-# Chrome launches this on the host; re-enter the sandbox to run the bridge.
-set -u
-
-FLATPAK_BIN="$(command -v flatpak 2>/dev/null || true)"
-if [ -z "\${FLATPAK_BIN}" ]; then
-  for candidate in /usr/bin/flatpak /usr/local/bin/flatpak /var/lib/flatpak/exports/bin/flatpak; do
-    if [ -x "\${candidate}" ]; then
-      FLATPAK_BIN="\${candidate}"
-      break
-    fi
-  done
-fi
-if [ -z "\${FLATPAK_BIN}" ]; then
-  echo "pearpass-native-host: flatpak binary not found on PATH" >&2
-  exit 127
-fi
-
-exec "\${FLATPAK_BIN}" run --command=${FLATPAK_NATIVE_HOST_COMMAND} ${FLATPAK_APP_ID} "$@"
-`
-    } else if (platform === 'darwin' || platform === 'linux') {
-      content = `#!/bin/bash
-# PearPass Native Messaging Host
-# Runs the native messaging bridge via Electron's embedded Node.js
-
-export ELECTRON_RUN_AS_NODE=1
-exec "${electronExecPath}" "${bridgeScriptPath}"
-`
-    } else if (platform === 'win32') {
-      content = `@echo off
-REM PearPass Native Messaging Host
-REM Runs the native messaging bridge via Electron's embedded Node.js
-
-set ELECTRON_RUN_AS_NODE=1
-"${electronExecPath}" "${bridgeScriptPath}"
-`
-    } else {
-      throw new Error(`Unsupported platform: ${platform}`)
-    }
+    const content = buildWrapperContent({
+      platform,
+      isFlatpak: isFlatpakRuntime(),
+      electronExecPath,
+      bridgeScriptPath
+    })
 
     await fs.writeFile(executablePath, content, 'utf8')
     if (platform !== 'win32') {


### PR DESCRIPTION
### Changes

- Extract wrapper-script generation into `electron/nativeHostWrapper.cjs`; pair-time path in `nativeMessagingSetup.js` now imports it (no behavior change).
- Add `refreshNativeHostWrapperIfPresent()` — atomic rewrite (tmp + rename) when the wrapper exists; no-op when absent.
- Wire `refreshNativeHostWrapper()` into `app.whenReady()` in `electron/main.cjs`: AppImage launches at a fresh `/tmp/.mount_*/` path each run, so paths baked into the wrapper at pair time go stale. Snap is skipped (stable mount path).
- Extract `getRuntimeExecPath()` to dedupe Windows Store execPath logic.
- Add `electron/nativeHostWrapper.test.js` — 9 tests covering per-platform wrapper content, atomic write, and present/absent refresh.