### PR TITLE
show scannable QR when viewing recovery phrases

### DIFF
--- a/src/containers/PassPhrase/PassPhraseV2.tsx
+++ b/src/containers/PassPhrase/PassPhraseV2.tsx
@@ -110,19 +110,18 @@ export const PassPhraseV2 = ({
   }, [value])
 
   useEffect(() => {
-    if (isCreateOrEdit || !value?.trim()) {
+    if (isCreateOrEdit || !passphraseWords.length) {
       setQrSvg('')
       return
     }
-    const words = parsePassphraseText(value)
-    if (!words.length) {
-      setQrSvg('')
-      return
-    }
-    generateQRCodeSVG(words.join(' '), { type: 'svg', margin: 4, errorCorrectionLevel: 'L' })
+    generateQRCodeSVG(passphraseWords.join(' '), {
+      type: 'svg',
+      margin: 4,
+      errorCorrectionLevel: 'L'
+    })
       .then(setQrSvg)
       .catch(() => setQrSvg(''))
-  }, [value, isCreateOrEdit])
+  }, [passphraseWords, isCreateOrEdit])
 
   const handlePasteFromClipboard = async () => {
     const pastedText = await pasteFromClipboard()

--- a/src/containers/PassPhrase/PassPhraseV2.tsx
+++ b/src/containers/PassPhrase/PassPhraseV2.tsx
@@ -21,6 +21,7 @@ import {
 import { useCopyToClipboard } from '../../hooks/useCopyToClipboard.electron'
 import { usePasteFromClipboard } from '../../hooks/usePasteFromClipboard'
 import { useToast } from '../../context/ToastContext'
+import { generateQRCodeSVG } from '@tetherto/pear-apps-utils-qr'
 import { useTranslation } from '../../hooks/useTranslation'
 import { createStyles } from './PassPhraseV2.styles'
 
@@ -89,6 +90,7 @@ export const PassPhraseV2 = ({
     getSelectedTypeForWords(initialWords.length)
   )
   const [passphraseWords, setPassphraseWords] = useState<string[]>(initialWords)
+  const [qrSvg, setQrSvg] = useState('')
 
   const detectAndUpdateSettings = (words: string[]) => {
     setSelectedType(getSelectedTypeForWords(words.length))
@@ -106,6 +108,21 @@ export const PassPhraseV2 = ({
     detectAndUpdateSettings(words)
     lastCommittedValueRef.current = value
   }, [value])
+
+  useEffect(() => {
+    if (isCreateOrEdit || !value?.trim()) {
+      setQrSvg('')
+      return
+    }
+    const words = parsePassphraseText(value)
+    if (!words.length) {
+      setQrSvg('')
+      return
+    }
+    generateQRCodeSVG(words.join(' '), { type: 'svg', margin: 4, errorCorrectionLevel: 'L' })
+      .then(setQrSvg)
+      .catch(() => setQrSvg(''))
+  }, [value, isCreateOrEdit])
 
   const handlePasteFromClipboard = async () => {
     const pastedText = await pasteFromClipboard()
@@ -202,6 +219,7 @@ export const PassPhraseV2 = ({
                 </div>
               ))}
             </div>
+            {qrSvg && <div data-testid="passphrase-qrcode-v2" style={{ width: 188, height: 188, margin: '12px auto' }} dangerouslySetInnerHTML={{ __html: qrSvg }} />}
           </div>
         ) : (
           optionsToRender.map((wordCount: number, index: number) => {


### PR DESCRIPTION
## Summary

When viewing a recovery phrase record in the vault detail panel (v2), show a scannable QR code below the read-only word grid so users can transfer the mnemonic to another device.

- QR is generated only in view mode (`!isCreateOrEdit`); create/edit flows are unchanged.
- Payload is the existing parsed word list joined with spaces (`passphraseWords.join(' ')`), matching what the UI displays.
- Uses `@tetherto/pear-apps-utils-qr` with `margin: 4` and `errorCorrectionLevel: 'L'` for reliable phone and wallet scanning.

## Test plan

- [ ] Open an existing recovery phrase in the vault side panel → QR appears below the words.
- [ ] Scan with a phone camera → decoded text is the space-separated recovery phrase.
- [ ] Scan with a wallet that supports mnemonic import (valid BIP39 12/24-word phrase).
- [ ] Create or edit a recovery phrase → no QR is shown.
- [ ] Wi-Fi QR and Add Device pairing QR still work as before.

## Recordings

<!-- Add screenshots or screen recording here -->

Made with [Cursor](https://cursor.com)