### PR TITLE
Show scannable QR when viewing recovery phrases

### DIFF
--- a/src/containers/PassPhrase/PassPhraseV2.tsx
+++ b/src/containers/PassPhrase/PassPhraseV2.tsx
@@ -21,6 +21,7 @@ import {
 import { useCopyToClipboard } from '../../hooks/useCopyToClipboard.electron'
 import { usePasteFromClipboard } from '../../hooks/usePasteFromClipboard'
 import { useToast } from '../../context/ToastContext'
+import { generateQRCodeSVG } from '@tetherto/pear-apps-utils-qr'
 import { useTranslation } from '../../hooks/useTranslation'
 import { createStyles } from './PassPhraseV2.styles'
 
@@ -89,6 +90,7 @@ export const PassPhraseV2 = ({
     getSelectedTypeForWords(initialWords.length)
   )
   const [passphraseWords, setPassphraseWords] = useState<string[]>(initialWords)
+  const [qrSvg, setQrSvg] = useState('')
 
   const detectAndUpdateSettings = (words: string[]) => {
     setSelectedType(getSelectedTypeForWords(words.length))
@@ -106,6 +108,20 @@ export const PassPhraseV2 = ({
     detectAndUpdateSettings(words)
     lastCommittedValueRef.current = value
   }, [value])
+
+  useEffect(() => {
+    if (isCreateOrEdit || !passphraseWords.length) {
+      setQrSvg('')
+      return
+    }
+    generateQRCodeSVG(passphraseWords.join(' '), {
+      type: 'svg',
+      margin: 4,
+      errorCorrectionLevel: 'L'
+    })
+      .then(setQrSvg)
+      .catch(() => setQrSvg(''))
+  }, [passphraseWords, isCreateOrEdit])
 
   const handlePasteFromClipboard = async () => {
     const pastedText = await pasteFromClipboard()
@@ -202,6 +218,7 @@ export const PassPhraseV2 = ({
                 </div>
               ))}
             </div>
+            {qrSvg && <div data-testid="passphrase-qrcode-v2" style={{ width: 188, height: 188, margin: '12px auto' }} dangerouslySetInnerHTML={{ __html: qrSvg }} />}
           </div>
         ) : (
           optionsToRender.map((wordCount: number, index: number) => {


### PR DESCRIPTION
## Summary

Scannable QR on the recovery phrase.

### UI

- Shown inview mode only (`PassPhraseV2`, under the word list).
- QR encodes `passphraseWords.join(' ')` (space-separated).
- Create/edit recovery phrase flows unchanged.

### Image 
<img width="1113" height="1004" alt="Screenshot 2026-05-19 at 4 04 44 PM" src="https://github.com/user-attachments/assets/5d0f6e36-a6c7-4fd8-b92f-7e9e824e3cc7" />
