### PR TITLE
Add Revoke Access flow to paired devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6313,7 +6313,7 @@
     "node_modules/@tetherto/pearpass-lib-native-messaging-bridge": {
       "name": "pearpass-lib-native-messaging-bridge",
       "version": "0.0.2",
-      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-native-messaging-bridge.git#7cf6c92aae2d2c8c6143a79429c45d5695d95550",
+      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-native-messaging-bridge.git#2a3ba917a572c325c969adfdfd74e45ef1cd5aeb",
       "dependencies": {
         "@tetherto/pearpass-lib-constants": "git+https://github.com/tetherto/pearpass-lib-constants.git",
         "bare-fs": "4.5.0",
@@ -6328,7 +6328,7 @@
     "node_modules/@tetherto/pearpass-lib-ui-kit": {
       "name": "pearpass-lib-ui-react-native-components",
       "version": "0.0.40",
-      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-ui-react-native-components.git#bba64ea96fad376a0f0b87d2729fe2742733d7d7",
+      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-ui-react-native-components.git#0301a142ff80a4c05b9efc245a9dc75a2bcdd8f2",
       "license": "Apache-2.0",
       "dependencies": {
         "react-strict-dom": "^0.0.55"
@@ -6367,7 +6367,7 @@
     "node_modules/@tetherto/pearpass-lib-vault": {
       "name": "pearpass-lib-vault",
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-vault.git#ecfff62dcef70c1acaf6d09a29bacf4001b8acb9",
+      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-vault.git#7e58479a45f8f802d2e8cb8145d526e74495c3af",
       "license": "Apache-2.0",
       "dependencies": {
         "@reduxjs/toolkit": "2.5.0",
@@ -6380,7 +6380,7 @@
     },
     "node_modules/@tetherto/pearpass-lib-vault-core": {
       "version": "0.2.0",
-      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-vault-core.git#89ae20deb70b18dffd6c3600fda0358176f32d17",
+      "resolved": "git+ssh://git@github.com/tetherto/pearpass-lib-vault-core.git#a2f686326cd41b14782be78168a04dfaa31beaa6",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/src/containers/Modal/PairedDevicesModalContent/index.tsx
+++ b/src/containers/Modal/PairedDevicesModalContent/index.tsx
@@ -3,23 +3,29 @@ import React, { useMemo } from 'react'
 import { formatDate } from '@tetherto/pear-apps-utils-date'
 import {
   Button,
+  ContextMenu,
   Dialog,
   ListItem,
+  NavbarListItem,
   Text,
   useTheme
 } from '@tetherto/pearpass-lib-ui-kit'
 import {
   Devices,
+  DoNotDisturb,
   LaptopMac,
   LaptopWindows,
+  MoreVert,
   PhoneIphone,
   Tablet
 } from '@tetherto/pearpass-lib-ui-kit/icons'
 import { useVault } from '@tetherto/pearpass-lib-vault'
 
-import { createStyles } from './styles'
+import { createStyles, DEVICE_ACTIONS_MENU_WIDTH } from './styles'
 import { useModal } from '../../../context/ModalContext'
 import { useTranslation } from '../../../hooks/useTranslation'
+import { getDeviceName } from '../../../utils/getDeviceName'
+import { RevokeAccessModalContentV2 } from '../RevokeAccessModalContentV2'
 
 const getDeviceDisplayName = (
   deviceName: string | undefined,
@@ -56,18 +62,39 @@ const getDeviceIcon = (deviceName?: string) => {
   return Devices
 }
 
+type Device = {
+  id?: string
+  name?: string
+  createdAt?: string | number | Date
+}
+
 export const PairedDevicesModalContent = () => {
   const { t } = useTranslation()
-  const { closeModal } = useModal()
+  const { closeModal, setModal } = useModal()
   const { theme } = useTheme()
   const styles = createStyles(theme.colors)
 
   const { data: vaultData } = useVault()
+  const vaultId = (vaultData as { id?: string } | undefined)?.id ?? ''
 
-  const devices = useMemo(
-    () => (Array.isArray(vaultData?.devices) ? vaultData.devices : []),
+  const devices = useMemo<Device[]>(
+    () =>
+      Array.isArray(vaultData?.devices) ? (vaultData.devices as Device[]) : [],
     [vaultData]
   )
+
+  const currentDeviceName = useMemo(() => getDeviceName(), [])
+
+  const openRevokeModal = (device: Device, displayName: string) => {
+    if (!device.id || !vaultId) return
+    setModal(
+      <RevokeAccessModalContentV2
+        vaultId={vaultId}
+        targetDeviceId={device.id}
+        deviceName={displayName}
+      />
+    )
+  }
 
   return (
     <Dialog
@@ -98,8 +125,9 @@ export const PairedDevicesModalContent = () => {
             const deviceName = getDeviceDisplayName(device.name, t)
             const DeviceIcon = getDeviceIcon(device.name)
             const createdAt = device.createdAt
-              ? formatDate(device.createdAt, 'dd-mmm-yyyy', ' ')
+              ? formatDate(new Date(device.createdAt), 'dd-mmm-yyyy', ' ')
               : null
+            const isCurrentDevice = device.name === currentDeviceName
 
             return (
               <ListItem
@@ -118,6 +146,41 @@ export const PairedDevicesModalContent = () => {
                   createdAt ? `${t('Paired on')} ${createdAt}` : undefined
                 }
                 testID={`see-devices-item-${device.id ?? index}`}
+                rightElement={
+                  isCurrentDevice || !device.id ? undefined : (
+                    <ContextMenu
+                      menuWidth={DEVICE_ACTIONS_MENU_WIDTH}
+                      testID={`see-devices-row-menu-${device.id}`}
+                      trigger={
+                        <Button
+                          variant="tertiary"
+                          size="small"
+                          aria-label={t('Device actions')}
+                          iconBefore={
+                            <MoreVert
+                              width={16}
+                              height={16}
+                              color={theme.colors.colorTextPrimary}
+                            />
+                          }
+                        />
+                      }
+                    >
+                      <NavbarListItem
+                        size="small"
+                        variant="destructive"
+                        icon={
+                          <DoNotDisturb
+                            color={theme.colors.colorSurfaceDestructiveElevated}
+                          />
+                        }
+                        label={t('Revoke Access')}
+                        testID={`see-devices-row-revoke-${device.id}`}
+                        onClick={() => openRevokeModal(device, deviceName)}
+                      />
+                    </ContextMenu>
+                  )
+                }
               />
             )
           })}

--- a/src/containers/Modal/PairedDevicesModalContent/styles.ts
+++ b/src/containers/Modal/PairedDevicesModalContent/styles.ts
@@ -1,6 +1,8 @@
 import type { ThemeColors } from '@tetherto/pearpass-lib-ui-kit'
 import { rawTokens } from '@tetherto/pearpass-lib-ui-kit'
 
+export const DEVICE_ACTIONS_MENU_WIDTH = 220
+
 export const createStyles = (colors: ThemeColors) => ({
   list: {
     display: 'flex' as const,

--- a/src/containers/Modal/RevokeAccessModalContentV2/RevokeAccessModalContentV2.styles.ts
+++ b/src/containers/Modal/RevokeAccessModalContentV2/RevokeAccessModalContentV2.styles.ts
@@ -1,0 +1,27 @@
+import { rawTokens } from '@tetherto/pearpass-lib-ui-kit'
+
+export const createStyles = () => ({
+  body: {
+    display: 'flex' as const,
+    flexDirection: 'column' as const,
+    gap: `${rawTokens.spacing12}px`,
+    width: '100%'
+  },
+  intro: {
+    display: 'flex' as const,
+    flexDirection: 'column' as const
+  },
+  bulletList: {
+    margin: 0,
+    paddingInlineStart: `${rawTokens.spacing20}px`,
+    listStyleType: 'disc' as const,
+    listStylePosition: 'outside' as const,
+    display: 'flex' as const,
+    flexDirection: 'column' as const,
+    gap: `${rawTokens.spacing12}px`
+  },
+  bulletItem: {
+    margin: 0,
+    display: 'list-item' as const
+  }
+})

--- a/src/containers/Modal/RevokeAccessModalContentV2/RevokeAccessModalContentV2.tsx
+++ b/src/containers/Modal/RevokeAccessModalContentV2/RevokeAccessModalContentV2.tsx
@@ -1,0 +1,130 @@
+import React, { useState } from 'react'
+
+import { Button, Dialog, Text, useTheme } from '@tetherto/pearpass-lib-ui-kit'
+// @ts-expect-error - declaration file is incomplete
+import { kickDevice } from '@tetherto/pearpass-lib-vault'
+
+import { createStyles } from './RevokeAccessModalContentV2.styles'
+import { useModal } from '../../../context/ModalContext'
+import { useToast } from '../../../context/ToastContext'
+import { useTranslation } from '../../../hooks/useTranslation'
+import { logger } from '../../../utils/logger'
+
+export type RevokeAccessModalContentV2Props = {
+  vaultId: string
+  targetDeviceId: string
+  deviceName: string
+  onClose?: () => void
+}
+
+export const RevokeAccessModalContentV2 = ({
+  vaultId,
+  targetDeviceId,
+  deviceName,
+  onClose
+}: RevokeAccessModalContentV2Props) => {
+  const { t } = useTranslation()
+  const { theme } = useTheme()
+  const styles = createStyles()
+  const { closeModal } = useModal()
+  const { setToast } = useToast()
+
+  const handleClose = onClose ?? closeModal
+
+  const [isLoading, setIsLoading] = useState(false)
+
+  const onRevoke = async () => {
+    if (isLoading) return
+    setIsLoading(true)
+    let failures: unknown[] = []
+    try {
+      ;({ failures } = await kickDevice({ vaultId, targetDeviceId }))
+    } catch (error) {
+      logger.error('RevokeAccessModalContentV2', 'kickDevice failed:', error)
+      setToast({
+        message: t("Couldn't revoke access. Please try again.")
+      })
+      setIsLoading(false)
+      return
+    }
+
+    closeModal()
+    setToast({
+      message: failures?.length
+        ? t(
+            "Couldn't reach the device. It will lose access next time it comes online."
+          )
+        : t('"{deviceName}" no longer has access to this vault', {
+            deviceName
+          })
+    })
+  }
+
+  return (
+    <Dialog
+      title={t('Revoke access for {deviceName}?', { deviceName })}
+      onClose={handleClose}
+      testID="revoke-access-dialog-v2"
+      closeButtonTestID="revoke-access-close-v2"
+      footer={
+        <>
+          <Button
+            variant="secondary"
+            size="small"
+            type="button"
+            onClick={handleClose}
+            disabled={isLoading}
+            data-testid="revoke-access-cancel-v2"
+          >
+            {t('Cancel')}
+          </Button>
+          <Button
+            variant="destructive"
+            size="small"
+            type="button"
+            isLoading={isLoading}
+            onClick={onRevoke}
+            data-testid="revoke-access-submit-v2"
+          >
+            {t('Revoke Access')}
+          </Button>
+        </>
+      }
+    >
+      <div style={styles.body} data-testid="revoke-access-body-v2">
+        <div style={styles.intro}>
+          <Text
+            as="p"
+            variant="caption"
+            color={theme.colors.colorTextSecondary}
+          >
+            {t('This will disconnect the device from future syncing.')}
+          </Text>
+          <Text
+            as="p"
+            variant="caption"
+            color={theme.colors.colorTextSecondary}
+          >
+            {t('Before you proceed, please note:')}
+          </Text>
+        </div>
+        <ul style={styles.bulletList}>
+          <li style={styles.bulletItem}>
+            <Text as="span" variant="caption">
+              {t(
+                'For Your Security: We recommend moving your items to a new vault and updating your passwords. This is especially important if the device was lost or stolen, as it ensures your data remains protected even if a local copy exists on the revoked device.'
+              )}
+            </Text>
+          </li>
+          <li style={styles.bulletItem}>
+            <Text as="span" variant="caption">
+              {t(
+                'Offline Data: Revoking access prevents future syncing, but it cannot remotely delete data that was already exported.'
+              )}
+            </Text>
+          </li>
+        </ul>
+      </div>
+    </Dialog>
+  )
+}

--- a/src/containers/Modal/RevokeAccessModalContentV2/index.ts
+++ b/src/containers/Modal/RevokeAccessModalContentV2/index.ts
@@ -1,0 +1,2 @@
+export { RevokeAccessModalContentV2 } from './RevokeAccessModalContentV2'
+export type { RevokeAccessModalContentV2Props } from './RevokeAccessModalContentV2'

--- a/src/electron/vaultClientProxy.js
+++ b/src/electron/vaultClientProxy.js
@@ -82,6 +82,7 @@ const VAULT_METHODS = [
   'activeVaultClose',
   'activeVaultAdd',
   'activeVaultRemove',
+  'activeVaultRemoveWriter',
   'activeVaultList',
   'activeVaultGet',
   'activeVaultCreateInvite',


### PR DESCRIPTION
Changes:
- New `RevokeAccessModalContentV2` master-password-free confirm dialog that calls `kickDevice` and surfaces a single success-or-partial-failure toast.
- `PairedDevicesModalContent`: per-row context menu with a destructive "Revoke Access" action; hidden on the self row.
- Wire `activeVaultRemoveWriter` into the renderer's `vaultClientProxy` (`VAULT_METHODS`) so the kick can call it over electron IPC.