### PR TITLE
Revoke Access follow-ups

### DIFF
--- a/src/containers/Modal/PairedDevicesModalContent/index.tsx
+++ b/src/containers/Modal/PairedDevicesModalContent/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 
 import { formatDate } from '@tetherto/pear-apps-utils-date'
 import {
@@ -19,12 +19,13 @@ import {
   PhoneIphone,
   Tablet
 } from '@tetherto/pearpass-lib-ui-kit/icons'
-import { useVault } from '@tetherto/pearpass-lib-vault'
+// @ts-expect-error - declaration file is incomplete
+import { getMyDeviceId, useVault } from '@tetherto/pearpass-lib-vault'
 
 import { createStyles, DEVICE_ACTIONS_MENU_WIDTH } from './styles'
 import { useModal } from '../../../context/ModalContext'
 import { useTranslation } from '../../../hooks/useTranslation'
-import { getDeviceName } from '../../../utils/getDeviceName'
+import { logger } from '../../../utils/logger'
 import { RevokeAccessModalContentV2 } from '../RevokeAccessModalContentV2'
 
 const getDeviceDisplayName = (
@@ -83,7 +84,21 @@ export const PairedDevicesModalContent = () => {
     [vaultData]
   )
 
-  const currentDeviceName = useMemo(() => getDeviceName(), [])
+  const [myDeviceId, setMyDeviceId] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    getMyDeviceId()
+      .then((id: string | null) => {
+        if (!cancelled) setMyDeviceId(id ?? null)
+      })
+      .catch((error: unknown) => {
+        logger.error('PairedDevicesModalContent', 'getMyDeviceId failed:', error)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [devices])
 
   const openRevokeModal = (device: Device, displayName: string) => {
     if (!device.id || !vaultId) return
@@ -127,7 +142,7 @@ export const PairedDevicesModalContent = () => {
             const createdAt = device.createdAt
               ? formatDate(new Date(device.createdAt), 'dd-mmm-yyyy', ' ')
               : null
-            const isCurrentDevice = device.name === currentDeviceName
+            const isCurrentDevice = !!myDeviceId && device.id === myDeviceId
 
             return (
               <ListItem

--- a/src/containers/Modal/PairedDevicesModalContent/index.tsx
+++ b/src/containers/Modal/PairedDevicesModalContent/index.tsx
@@ -19,7 +19,6 @@ import {
   PhoneIphone,
   Tablet
 } from '@tetherto/pearpass-lib-ui-kit/icons'
-// @ts-expect-error - declaration file is incomplete
 import { getMyDeviceId, useVault } from '@tetherto/pearpass-lib-vault'
 
 import { createStyles, DEVICE_ACTIONS_MENU_WIDTH } from './styles'
@@ -98,7 +97,7 @@ export const PairedDevicesModalContent = () => {
     return () => {
       cancelled = true
     }
-  }, [devices])
+  }, [])
 
   const openRevokeModal = (device: Device, displayName: string) => {
     if (!device.id || !vaultId) return

--- a/src/containers/Modal/RevokeAccessModalContentV2/RevokeAccessModalContentV2.tsx
+++ b/src/containers/Modal/RevokeAccessModalContentV2/RevokeAccessModalContentV2.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 
 import { Button, Dialog, Text, useTheme } from '@tetherto/pearpass-lib-ui-kit'
-// @ts-expect-error - declaration file is incomplete
 import { kickDevice } from '@tetherto/pearpass-lib-vault'
 
 import { createStyles } from './RevokeAccessModalContentV2.styles'

--- a/src/services/handlers/VaultHandlers.js
+++ b/src/services/handlers/VaultHandlers.js
@@ -147,6 +147,11 @@ export class VaultHandlers {
     return { success: true }
   }
 
+  async activeVaultRemoveWriter(params) {
+    await this.client.activeVaultRemoveWriter(params.writerKey)
+    return { success: true }
+  }
+
   async activeVaultClose() {
     await this.client.activeVaultClose()
     return { success: true }

--- a/src/services/nativeMessagingIPCServer.js
+++ b/src/services/nativeMessagingIPCServer.js
@@ -264,6 +264,10 @@ export class NativeMessagingIPCServer {
       vaultHandlers.activeVaultRemove.bind(vaultHandlers)
     )
     this.secureMethodRegistry.register(
+      'activeVaultRemoveWriter',
+      vaultHandlers.activeVaultRemoveWriter.bind(vaultHandlers)
+    )
+    this.secureMethodRegistry.register(
       'activeVaultClose',
       vaultHandlers.activeVaultClose.bind(vaultHandlers)
     )

--- a/src/services/nativeMessagingIPCServer.js
+++ b/src/services/nativeMessagingIPCServer.js
@@ -265,7 +265,8 @@ export class NativeMessagingIPCServer {
     )
     this.secureMethodRegistry.register(
       'activeVaultRemoveWriter',
-      vaultHandlers.activeVaultRemoveWriter.bind(vaultHandlers)
+      vaultHandlers.activeVaultRemoveWriter.bind(vaultHandlers),
+      { requiresStatus: ['encryption', 'vaults', 'activeVault'] }
     )
     this.secureMethodRegistry.register(
       'activeVaultClose',

--- a/src/services/nativeMessagingIPCServer.test.js
+++ b/src/services/nativeMessagingIPCServer.test.js
@@ -141,6 +141,9 @@ jest.mock('./handlers/VaultHandlers', () => ({
     this.activeVaultList = jest.fn().mockResolvedValue({ data: [] })
     this.activeVaultAdd = jest.fn().mockResolvedValue({ success: true })
     this.activeVaultRemove = jest.fn().mockResolvedValue({ success: true })
+    this.activeVaultRemoveWriter = jest
+      .fn()
+      .mockResolvedValue({ success: true })
     this.activeVaultClose = jest.fn().mockResolvedValue({ success: true })
     this.activeVaultCreateInvite = jest
       .fn()
@@ -197,6 +200,7 @@ const mockPearpassClient = {
   activeVaultList: jest.fn(),
   activeVaultAdd: jest.fn(),
   activeVaultRemove: jest.fn(),
+  activeVaultRemoveWriter: jest.fn(),
   activeVaultClose: jest.fn(),
   activeVaultCreateInvite: jest.fn(),
   activeVaultDeleteInvite: jest.fn(),

--- a/src/shared/commandDefinitions.js
+++ b/src/shared/commandDefinitions.js
@@ -32,6 +32,7 @@ const COMMAND_DEFINITIONS = [
   { id: 1014, name: 'activeVaultList' },
   { id: 1015, name: 'activeVaultAdd' },
   { id: 1016, name: 'activeVaultRemove' },
+  { id: 1048, name: 'activeVaultRemoveWriter' },
   { id: 1017, name: 'activeVaultClose' },
   { id: 1018, name: 'activeVaultCreateInvite' },
   { id: 1019, name: 'activeVaultDeleteInvite' },

--- a/src/types/modules.d.ts
+++ b/src/types/modules.d.ts
@@ -60,6 +60,14 @@ declare module '@tetherto/pearpass-lib-vault' {
 
   export const setPearpassVaultClient: any
   export function setCurrentDeviceName(name: string | null): void
+  export function getMyDeviceId(): Promise<string | null>
+  export function kickDevice(params: {
+    vaultId: string
+    targetDeviceId: string
+  }): Promise<{
+    results: Array<{ targetDeviceId: string; channel: 'outbox' }>
+    failures: Array<{ targetDeviceId: string; error: Error }>
+  }>
   export const VaultProvider: any
   export function useVaults(options?: {
     onCompleted?: (payload: Vault[]) => void


### PR DESCRIPTION
Two follow-ups to the revoke-access merge, both scoped to desktop:

Changes:
- `PairedDevicesModalContent`: detect self device by `getMyDeviceId()` (writerKey-derived id) instead of `device.name === os.hostname() + os.platform() + os.release()`. The name-based comparison drifts on OS updates or vault renames; writer-key-derived id matches the identity the kick flow uses.
- Bridge IPC: register `activeVaultRemoveWriter` in `src/shared/commandDefinitions.js`, add a handler in `services/handlers/VaultHandlers.js`, wire it through `services/nativeMessagingIPCServer.js`. Without this the extension's revoke call reaches the bridge with the verb but is rejected as `UNKNOWN_METHOD`.