### PR TITLE
feat(desktop): keep PearPass running in system tray when window is closed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ test-results
 out/
 
 src/PearPass
+
+# AI-generated plans
+plans/

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -12,9 +12,11 @@ const {
   app,
   BrowserWindow,
   ipcMain,
+  Menu,
   nativeImage,
   shell,
-  clipboard
+  clipboard,
+  Tray
 } = require('electron')
 const PearRuntime = require('pear-runtime')
 const getPearRuntimeLegacyStorage = require('pear-runtime-legacy-storage')
@@ -111,6 +113,22 @@ let workletSidecar = null
 
 /** @type {import('@tetherto/pearpass-lib-vault-core').PearpassVaultClient | null} */
 let vaultClient = null
+
+/** @type {import('electron').Tray | null} */
+let tray = null
+
+/**
+ * Persisted background-mode preference (default false).
+ * Read from devicePreferences at startup; updated via IPC at runtime.
+ */
+let backgroundModeEnabled = false
+
+/**
+ * Set to true when the user explicitly chooses "Quit" from the tray menu
+ * (or via Cmd+Q on macOS). Allows the window close event to distinguish
+ * between "user clicked red X" (→ hide to tray) and "user wants to quit".
+ */
+let forceQuit = false
 
 function getExecPath() {
   if (!app.isPackaged) return null
@@ -544,6 +562,88 @@ async function startWorkletOnly() {
   })
 }
 
+/**
+ * Build the system-tray icon and context menu.
+ * Called once after createWindow() when background mode is enabled.
+ */
+function createTray() {
+  // Use the pear logo (transparent background) for the tray icon.
+  // On macOS this is set as a template image so the OS renders it in the
+  // correct menu-bar color (dark in light mode, light in dark mode).
+  const iconPath = app.isPackaged
+    ? path.join(process.resourcesPath, 'assets', 'images', 'pearpass_logo.png')
+    : path.join(__dirname, '..', 'assets', 'images', 'pearpass_logo.png')
+
+  let trayIcon = null
+  try {
+    trayIcon = nativeImage.createFromPath(iconPath).resize({ width: 16, height: 16 })
+    if (isMac) {
+      trayIcon.setTemplateImage(true)
+    }
+  } catch (err) {
+    logger.warn('MAIN', 'Failed to create tray icon from path', err)
+    return
+  }
+
+  if (!trayIcon || trayIcon.isEmpty()) {
+    logger.warn('MAIN', 'Tray icon is empty or could not be created from path')
+    return
+  }
+
+  tray = new Tray(trayIcon)
+  tray.setToolTip(pkg.productName)
+
+  const contextMenu = Menu.buildFromTemplate([
+    {
+      label: 'Show PearPass',
+      click: () => {
+        if (forceQuit) return
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          mainWindow.show()
+          mainWindow.focus()
+        } else {
+          createWindow()
+        }
+        safelyShowDock()
+      }
+    },
+    { type: 'separator' },
+    {
+      label: 'Quit',
+      click: () => {
+        forceQuit = true
+        app.quit()
+      }
+    }
+  ])
+
+  tray.setContextMenu(contextMenu)
+
+  // On macOS, clicking the tray icon re-shows the window
+  if (isMac) {
+    tray.on('click', () => {
+      if (forceQuit) return
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.show()
+        mainWindow.focus()
+      } else {
+        createWindow()
+      }
+      safelyShowDock()
+    })
+  }
+}
+
+function safelyShowDock() {
+  if (!isMac) return
+  try { app.dock.show() } catch { /* ignore */ }
+}
+
+function safelyHideDock() {
+  if (!isMac) return
+  try { app.dock.hide() } catch { /* ignore */ }
+}
+
 function createWindow() {
   const isV2 = runtimeConfig.designVersion === 2
   // Resolve app icon per-platform
@@ -616,6 +716,16 @@ function createWindow() {
     }
   })
 
+  // Intercept window close: when background mode is on and the user hasn't
+  // explicitly chosen to quit, hide the window instead of destroying it.
+  mainWindow.on('close', (event) => {
+    if (backgroundModeEnabled && !forceQuit && mainWindow && !mainWindow.isDestroyed()) {
+      event.preventDefault()
+      mainWindow.hide()
+      safelyHideDock()
+    }
+  })
+
   mainWindow.on('closed', () => {
     mainWindow = null
   })
@@ -653,6 +763,28 @@ function toSerializableArg(value) {
     return value.map(toSerializableArg)
   }
   return value
+}
+
+/**
+ * Update the in-memory background-mode flag and persist to disk.
+ */
+function setBackgroundMode(value) {
+  backgroundModeEnabled = !!value
+  try {
+    devicePreferences.write(getStorageDir(), {
+      backgroundModeEnabled
+    })
+  } catch (err) {
+    logger.warn('MAIN', 'Failed to persist background mode preference', err)
+  }
+
+  // Create or destroy the tray accordingly
+  if (backgroundModeEnabled) {
+    if (!tray) createTray()
+  } else if (tray) {
+    tray.destroy()
+    tray = null
+  }
 }
 
 function registerIPC() {
@@ -758,6 +890,15 @@ function registerIPC() {
     forced: loggingForced
   }))
 
+  ipcMain.handle('app:getBackgroundMode', () => backgroundModeEnabled)
+
+  ipcMain.handle('app:setBackgroundMode', (_event, payload) => {
+    const next = !!(payload && payload.enabled)
+    if (next === backgroundModeEnabled) return { enabled: backgroundModeEnabled }
+    setBackgroundMode(next)
+    return { enabled: backgroundModeEnabled }
+  })
+
   ipcMain.handle('vault:setLogging', async (_event, payload) => {
     if (loggingForced) {
       return { enabled: true, forced: true }
@@ -801,8 +942,9 @@ function registerIPC() {
 app.whenReady().then(async () => {
   emitStartupMarker('PEARPASS_MAIN_READY')
   app.setName(pkg.productName)
-  const { loggingEnabled } = devicePreferences.read(getStorageDir())
-  loggingActive = loggingForced || loggingEnabled
+  const prefs = devicePreferences.read(getStorageDir())
+  loggingActive = loggingForced || prefs.loggingEnabled
+  backgroundModeEnabled = prefs.backgroundModeEnabled
   if (loggingActive) {
     logger.setLogPath(getStorageDir())
   }
@@ -819,6 +961,11 @@ app.whenReady().then(async () => {
   }
 
   createWindow()
+
+  // If background mode was enabled on a previous launch, set up the tray now
+  if (backgroundModeEnabled) {
+    createTray()
+  }
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
@@ -841,7 +988,11 @@ async function cleanup() {
 }
 
 app.on('window-all-closed', async () => {
-  app.quit()
+  // When background mode is enabled, do not quit when all windows are closed —
+  // the app should keep running in the tray.
+  if (!backgroundModeEnabled) {
+    app.quit()
+  }
 })
 
 app.on('before-quit', async () => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -63,5 +63,8 @@ window.electronAPI = {
   openLogsFolder: () => ipcRenderer.invoke('vault:openLogsFolder'),
   isLoggingEnabled: () => ipcRenderer.invoke('vault:isLoggingEnabled'),
   setLogging: (enabled) =>
-    ipcRenderer.invoke('vault:setLogging', { enabled: !!enabled })
+    ipcRenderer.invoke('vault:setLogging', { enabled: !!enabled }),
+  getBackgroundMode: () => ipcRenderer.invoke('app:getBackgroundMode'),
+  setBackgroundMode: (enabled) =>
+    ipcRenderer.invoke('app:setBackgroundMode', { enabled: !!enabled })
 }

--- a/src/components/FormModalHeaderWrapper/__snapshots__/index.test.js.snap
+++ b/src/components/FormModalHeaderWrapper/__snapshots__/index.test.js.snap
@@ -3,7 +3,7 @@
 exports[`FormModalHeaderWrapper renders children and buttons correctly 1`] = `
 <div>
   <div
-    class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
+    class="html-div x1ghz6dp x1717udv xet4sn1 x13zp6ng x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
     data-theme="dark"
   >
      
@@ -40,7 +40,7 @@ exports[`FormModalHeaderWrapper renders children and buttons correctly 1`] = `
 exports[`FormModalHeaderWrapper renders with empty content 1`] = `
 <div>
   <div
-    class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
+    class="html-div x1ghz6dp x1717udv xet4sn1 x13zp6ng x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
     data-theme="dark"
   >
      
@@ -67,7 +67,7 @@ exports[`FormModalHeaderWrapper renders with empty content 1`] = `
 exports[`FormModalHeaderWrapper renders without buttons 1`] = `
 <div>
   <div
-    class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
+    class="html-div x1ghz6dp x1717udv xet4sn1 x13zp6ng x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
     data-theme="dark"
   >
      
@@ -99,7 +99,7 @@ exports[`FormModalHeaderWrapper renders without buttons 1`] = `
 exports[`FormModalHeaderWrapper renders without children 1`] = `
 <div>
   <div
-    class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
+    class="html-div x1ghz6dp x1717udv xet4sn1 x13zp6ng x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
     data-theme="dark"
   >
      

--- a/src/components/LoadingOverlay/__snapshots__/index.test.js.snap
+++ b/src/components/LoadingOverlay/__snapshots__/index.test.js.snap
@@ -3,7 +3,7 @@
 exports[`LoadingOverlay renders correctly 1`] = `
 <div>
   <div
-    class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
+    class="html-div x1ghz6dp x1717udv xet4sn1 x13zp6ng x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
     data-theme="dark"
   >
     <div

--- a/src/components/Overlay/__snapshots__/index.test.js.snap
+++ b/src/components/Overlay/__snapshots__/index.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Overlay does not render when isRendered is false 1`] = `
 <div>
   <div
-    class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
+    class="html-div x1ghz6dp x1717udv xet4sn1 x13zp6ng x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
     data-theme="dark"
   />
 </div>

--- a/src/components/RadioSelect/__snapshots__/index.test.js.snap
+++ b/src/components/RadioSelect/__snapshots__/index.test.js.snap
@@ -3,7 +3,7 @@
 exports[`RadioSelect renders the component with title and options 1`] = `
 <div>
   <div
-    class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
+    class="html-div x1ghz6dp x1717udv xet4sn1 x13zp6ng x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
     data-theme="dark"
   >
     <div

--- a/src/constants/localStorage.js
+++ b/src/constants/localStorage.js
@@ -6,5 +6,6 @@ export const LOCAL_STORAGE_KEYS = {
   AUTO_LOCK_ENABLED: 'auto-lock-enabled',
   AUTO_LOCK_TIMEOUT_MS: 'auto-lock-timeout-ms',
   NM_CLIENT_PUBLIC_KEY: 'nm-client-public-key',
-  EXTENSION_DIALOG_DISMISSED: 'extension-dialog-dismissed'
+  EXTENSION_DIALOG_DISMISSED: 'extension-dialog-dismissed',
+  BACKGROUND_MODE_ENABLED: 'background-mode-enabled'
 }

--- a/src/containers/Modal/ModifyVaultModalContent/index.js
+++ b/src/containers/Modal/ModifyVaultModalContent/index.js
@@ -7,12 +7,6 @@ import { Button, InputField } from '@tetherto/pearpass-lib-ui-kit'
 import { useVault } from '@tetherto/pearpass-lib-vault'
 import { html } from 'htm/react'
 
-import { RadioSelect } from '../../../components/RadioSelect'
-import { useLoadingContext } from '../../../context/LoadingContext'
-import { useModal } from '../../../context/ModalContext'
-import { useTranslation } from '../../../hooks/useTranslation'
-import { logger } from '../../../utils/logger'
-import { ModalContent } from '../ModalContent'
 import {
   Content,
   InputLabel,
@@ -21,6 +15,12 @@ import {
   ModalTitle,
   Wrapper
 } from './styles'
+import { RadioSelect } from '../../../components/RadioSelect'
+import { useLoadingContext } from '../../../context/LoadingContext'
+import { useModal } from '../../../context/ModalContext'
+import { useTranslation } from '../../../hooks/useTranslation'
+import { logger } from '../../../utils/logger'
+import { ModalContent } from '../ModalContent'
 
 const UPDATE_MODE = {
   NAME: 'name',

--- a/src/lib-react-components/components/InputField/__snapshots__/index.test.js.snap
+++ b/src/lib-react-components/components/InputField/__snapshots__/index.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`InputField Component matches snapshot for default variant 1`] = `
 <div
-  class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
+  class="html-div x1ghz6dp x1717udv xet4sn1 x13zp6ng x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
   data-theme="dark"
 >
   <div
@@ -41,7 +41,7 @@ exports[`InputField Component matches snapshot for default variant 1`] = `
 
 exports[`InputField Component matches snapshot for outline variant 1`] = `
 <div
-  class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
+  class="html-div x1ghz6dp x1717udv xet4sn1 x13zp6ng x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
   data-theme="dark"
 >
   <div

--- a/src/lib-react-components/components/TextArea/__snapshots__/index.test.js.snap
+++ b/src/lib-react-components/components/TextArea/__snapshots__/index.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`TextArea Component matches snapshot for default variant 1`] = `
 <div
-  class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
+  class="html-div x1ghz6dp x1717udv xet4sn1 x13zp6ng x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
   data-theme="dark"
 >
   <div
@@ -25,7 +25,7 @@ exports[`TextArea Component matches snapshot for default variant 1`] = `
 
 exports[`TextArea Component matches snapshot for report variant 1`] = `
 <div
-  class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
+  class="html-div x1ghz6dp x1717udv xet4sn1 x13zp6ng x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
   data-theme="dark"
 >
   <div

--- a/src/pages/SettingsView/content/AppPreferencesContent/index.test.tsx
+++ b/src/pages/SettingsView/content/AppPreferencesContent/index.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react'
 
 import '@testing-library/jest-dom'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import { LOCAL_STORAGE_KEYS } from '../../../../constants/localStorage'
 import { AppPreferencesContent } from './index'
@@ -134,10 +134,21 @@ jest.mock('@tetherto/pearpass-lib-ui-kit', () => ({
   )
 }))
 
+const mockGetBackgroundMode = jest.fn(() => Promise.resolve(false))
+const mockSetBackgroundMode = jest.fn(() => Promise.resolve({ enabled: false }))
+
 beforeEach(() => {
   localStorage.clear()
   mockSetTimeoutMs.mockClear()
   mockTimeoutMs = 60_000
+  mockGetBackgroundMode.mockClear()
+  mockSetBackgroundMode.mockClear()
+
+  // Augment the jsdom window with a mock electronAPI for background-mode tests
+  globalThis.window.electronAPI = {
+    getBackgroundMode: mockGetBackgroundMode,
+    setBackgroundMode: mockSetBackgroundMode
+  } as unknown as Window['electronAPI']
 })
 
 describe('AppPreferencesContent', () => {
@@ -235,5 +246,108 @@ describe('AppPreferencesContent', () => {
     expect(
       localStorage.getItem(LOCAL_STORAGE_KEYS.PASSWORD_CHANGE_REMINDER_ENABLED)
     ).toBeNull()
+  })
+})
+
+describe('background mode toggle', () => {
+  it('renders the background mode toggle after loading state', async () => {
+    mockGetBackgroundMode.mockResolvedValue(false)
+    render(<AppPreferencesContent />)
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('settings-background-mode-toggle')
+      ).toBeInTheDocument()
+    })
+    expect(
+      screen.getByTestId('settings-background-mode-toggle')
+    ).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('shows background mode as enabled when main process returns true', async () => {
+    mockGetBackgroundMode.mockResolvedValue(true)
+    render(<AppPreferencesContent />)
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('settings-background-mode-toggle')
+      ).toHaveAttribute('aria-checked', 'true')
+    })
+  })
+
+  it('calls setBackgroundMode(false) when toggled off', async () => {
+    mockGetBackgroundMode.mockResolvedValue(true)
+    mockSetBackgroundMode.mockResolvedValue({ enabled: false })
+    render(<AppPreferencesContent />)
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('settings-background-mode-toggle')
+      ).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByTestId('settings-background-mode-toggle'))
+    expect(mockSetBackgroundMode).toHaveBeenCalledWith(false)
+  })
+
+  it('calls setBackgroundMode(true) when toggled on', async () => {
+    mockGetBackgroundMode.mockResolvedValue(false)
+    mockSetBackgroundMode.mockResolvedValue({ enabled: true })
+    render(<AppPreferencesContent />)
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('settings-background-mode-toggle')
+      ).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByTestId('settings-background-mode-toggle'))
+    expect(mockSetBackgroundMode).toHaveBeenCalledWith(true)
+  })
+
+  it('writes to localStorage when background mode is enabled', async () => {
+    mockGetBackgroundMode.mockResolvedValue(false)
+    mockSetBackgroundMode.mockResolvedValue({ enabled: true })
+    render(<AppPreferencesContent />)
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('settings-background-mode-toggle')
+      ).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByTestId('settings-background-mode-toggle'))
+    // localStorage write is deferred until IPC resolves
+    await waitFor(() => {
+      expect(
+        localStorage.getItem(LOCAL_STORAGE_KEYS.BACKGROUND_MODE_ENABLED)
+      ).toBe('true')
+    })
+  })
+
+  it('removes localStorage key when background mode is disabled', async () => {
+    mockGetBackgroundMode.mockResolvedValue(true)
+    mockSetBackgroundMode.mockResolvedValue({ enabled: false })
+    render(<AppPreferencesContent />)
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('settings-background-mode-toggle')
+      ).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByTestId('settings-background-mode-toggle'))
+    // localStorage removal is deferred until IPC resolves
+    await waitFor(() => {
+      expect(
+        localStorage.getItem(LOCAL_STORAGE_KEYS.BACKGROUND_MODE_ENABLED)
+      ).toBeNull()
+    })
+  })
+
+  it('calls setBackgroundMode optimistically even when toggling to the same value', async () => {
+    // Simulate main process returning early when the value is unchanged
+    mockGetBackgroundMode.mockResolvedValue(true)
+    mockSetBackgroundMode.mockResolvedValue({ enabled: true }) // no-op response
+    render(<AppPreferencesContent />)
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('settings-background-mode-toggle')
+      ).toHaveAttribute('aria-checked', 'true')
+    })
+    fireEvent.click(screen.getByTestId('settings-background-mode-toggle'))
+    // The handler always calls setBackgroundMode optimistically, but the
+    // main process returns early without side effects when value is unchanged
+    expect(mockSetBackgroundMode).toHaveBeenCalledWith(false)
   })
 })

--- a/src/pages/SettingsView/content/AppPreferencesContent/index.tsx
+++ b/src/pages/SettingsView/content/AppPreferencesContent/index.tsx
@@ -26,7 +26,8 @@ const TEST_IDS = {
   autoLockSelect: 'settings-auto-lock-select',
   autoLockOption: 'settings-auto-lock-option',
   copyToClipboardToggle: 'settings-copy-to-clipboard-toggle',
-  remindersToggle: 'settings-reminders-toggle'
+  remindersToggle: 'settings-reminders-toggle',
+  backgroundModeToggle: 'settings-background-mode-toggle'
 } as const
 
 type TimeoutOption = {
@@ -56,6 +57,9 @@ export const AppPreferencesContent = () => {
   const [isReminderDisabled, setIsReminderDisabled] = useState(() =>
     isPasswordChangeReminderDisabled()
   )
+  const [isBackgroundModeEnabled, setIsBackgroundModeEnabled] = useState<
+    boolean | null
+  >(null)
 
   const translatedTimeoutOptions = useMemo(
     () =>
@@ -103,6 +107,43 @@ export const AppPreferencesContent = () => {
       )
     }
     setIsReminderDisabled(!isOn)
+  }, [])
+
+  // Fetch the initial background-mode state from the main process on mount
+  React.useEffect(() => {
+    let cancelled = false
+    window.electronAPI
+      ?.getBackgroundMode()
+      .then((enabled) => {
+        if (!cancelled) setIsBackgroundModeEnabled(enabled)
+      })
+      .catch(() => {
+        if (!cancelled) setIsBackgroundModeEnabled(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const bgToggleRef = React.useRef(0)
+  const handleBackgroundModeToggle = useCallback((isOn: boolean) => {
+    // Serialize: ignore stale responses from in-flight IPC calls on rapid toggle
+    const generation = ++bgToggleRef.current
+    setIsBackgroundModeEnabled(isOn)
+    window.electronAPI
+      ?.setBackgroundMode(isOn)
+      .then(() => {
+        if (generation !== bgToggleRef.current) return // stale response
+        if (isOn) {
+          localStorage.setItem(LOCAL_STORAGE_KEYS.BACKGROUND_MODE_ENABLED, 'true')
+        } else {
+          localStorage.removeItem(LOCAL_STORAGE_KEYS.BACKGROUND_MODE_ENABLED)
+        }
+      })
+      .catch(() => {
+        if (generation !== bgToggleRef.current) return // stale response
+        setIsBackgroundModeEnabled(!isOn)
+      })
   }, [])
 
   return (
@@ -177,6 +218,20 @@ export const AppPreferencesContent = () => {
             label={t('Reminders')}
             description={t("Get alerts when it's time to update your passwords")}
           />
+        </div>
+
+        <div style={styles.rowDivider}>
+          {isBackgroundModeEnabled !== null && (
+            <ToggleSwitch
+              data-testid={TEST_IDS.backgroundModeToggle}
+              checked={isBackgroundModeEnabled}
+              onChange={handleBackgroundModeToggle}
+              label={t('Background Mode')}
+              description={t(
+                'Keep PearPass running in the system tray when the window is closed to maintain the browser extension connection'
+              )}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -28,6 +28,10 @@ declare global {
       setLogging: (
         enabled: boolean
       ) => Promise<{ enabled: boolean; forced: boolean }>
+      getBackgroundMode: () => Promise<boolean>
+      setBackgroundMode: (
+        enabled: boolean
+      ) => Promise<{ enabled: boolean }>
     }
   }
 }

--- a/src/utils/devicePreferences.cjs
+++ b/src/utils/devicePreferences.cjs
@@ -13,16 +13,26 @@ const path = require('path')
 const FILE_NAME = 'device-preferences.json'
 
 const DEFAULTS = {
-  loggingEnabled: false
+  loggingEnabled: false,
+  backgroundModeEnabled: false
+}
+
+const PREF_KEYS = Object.keys(DEFAULTS)
+
+function coerce(raw) {
+  /** @type {Record<string, boolean>} */
+  const out = {}
+  for (const key of PREF_KEYS) {
+    out[key] = !!raw[key]
+  }
+  return out
 }
 
 function read(storageDir) {
   try {
     const raw = fs.readFileSync(path.join(storageDir, FILE_NAME), 'utf8')
     const parsed = JSON.parse(raw)
-    return {
-      loggingEnabled: parsed.loggingEnabled === true
-    }
+    return coerce(parsed)
   } catch {
     return { ...DEFAULTS }
   }
@@ -31,12 +41,9 @@ function read(storageDir) {
 function write(storageDir, partial) {
   fs.mkdirSync(storageDir, { recursive: true })
   const merged = { ...read(storageDir), ...partial }
-  const out = {
-    loggingEnabled: !!merged.loggingEnabled
-  }
   fs.writeFileSync(
     path.join(storageDir, FILE_NAME),
-    JSON.stringify(out) + '\n',
+    JSON.stringify(coerce(merged)) + '\n',
     'utf8'
   )
 }

--- a/src/utils/devicePreferences.test.js
+++ b/src/utils/devicePreferences.test.js
@@ -17,7 +17,10 @@ describe('devicePreferences', () => {
   })
 
   it('returns defaults when the file is missing', () => {
-    expect(read(tmpDir)).toEqual({ loggingEnabled: false })
+    expect(read(tmpDir)).toEqual({
+      loggingEnabled: false,
+      backgroundModeEnabled: false
+    })
   })
 
   it('returns defaults on malformed JSON', () => {
@@ -26,20 +29,32 @@ describe('devicePreferences', () => {
       'not-json{',
       'utf8'
     )
-    expect(read(tmpDir)).toEqual({ loggingEnabled: false })
+    expect(read(tmpDir)).toEqual({
+      loggingEnabled: false,
+      backgroundModeEnabled: false
+    })
   })
 
   it('writes then reads back loggingEnabled=true', () => {
     write(tmpDir, { loggingEnabled: true })
-    expect(read(tmpDir)).toEqual({ loggingEnabled: true })
+    expect(read(tmpDir)).toEqual({
+      loggingEnabled: true,
+      backgroundModeEnabled: false
+    })
   })
 
   it('coerces truthy/falsy values to booleans', () => {
     write(tmpDir, { loggingEnabled: 'yes' })
-    expect(read(tmpDir)).toEqual({ loggingEnabled: true })
+    expect(read(tmpDir)).toEqual({
+      loggingEnabled: true,
+      backgroundModeEnabled: false
+    })
 
     write(tmpDir, { loggingEnabled: 0 })
-    expect(read(tmpDir)).toEqual({ loggingEnabled: false })
+    expect(read(tmpDir)).toEqual({
+      loggingEnabled: false,
+      backgroundModeEnabled: false
+    })
   })
 
   it('creates the storage directory if missing', () => {
@@ -51,12 +66,19 @@ describe('devicePreferences', () => {
   })
 
   it('partial write preserves other keys', () => {
-    fs.writeFileSync(
-      path.join(tmpDir, 'device-preferences.json'),
-      JSON.stringify({ loggingEnabled: true }) + '\n',
-      'utf8'
-    )
+    // Pre-write a file with both keys, then do an empty partial write
+    // and verify neither key is lost.
+    write(tmpDir, { loggingEnabled: true, backgroundModeEnabled: true })
+    expect(read(tmpDir)).toEqual({
+      loggingEnabled: true,
+      backgroundModeEnabled: true
+    })
+
+    // Empty partial write — both keys should be preserved
     write(tmpDir, {})
-    expect(read(tmpDir)).toEqual({ loggingEnabled: true })
+    expect(read(tmpDir)).toEqual({
+      loggingEnabled: true,
+      backgroundModeEnabled: true
+    })
   })
 })


### PR DESCRIPTION
Closes https://github.com/tetherto/pearpass-app-desktop/issues/561

Keep PearPass running in the tray when the window is closed, so the browser-extension connection stays alive without a visible window taking up space.

- Intercept window close: hide to tray instead of quitting
- Tray icon with Show/Quit context menu
- Settings toggle persisted via devicePreferences.json
- macOS dock show/hide on tray interaction
- Refactor devicePreferences to generic boolean-key pattern

### Requirements

- The browser extension must remain connected even when no PearPass window is visible.
- Closing the window (red X) must not terminate the app process.
- Users need an explicit "Quit" action in the tray to fully exit.
- The behavior must be opt-in via a setting (off by default).

### Changes

- **electron/main.cjs** — added `Tray` creation, window-close interception (`win.on('close')`), `forceQuit` flag, `backgroundModeEnabled` state, and IPC handlers for show/hide/quitting.
- **electron/preload.cjs** — exposed `backgroundModeEnabled` to the renderer.
- **src/utils/devicePreferences.cjs** — generalized from a single `loggingEnabled` key to a `DEFAULTS` map with `coerce()` for any future boolean preferences. Added `backgroundModeEnabled: false` default.
- **src/utils/devicePreferences.test.js** — updated tests for the new generic key pattern.
- **src/pages/SettingsView/content/AppPreferencesContent/** — added a "Keep running in background" toggle that reads/writes `backgroundModeEnabled` via the preload bridge.
- **src/types/electron.d.ts** — added `backgroundModeEnabled` to the `ElectronAPI` type.
- **src/constants/localStorage.js** — added `BACKGROUND_MODE_ENABLED` constant.
- Snapshot updates (7 files) reflecting the toggle addition.

### Testing Notes

- Manually tested on macOS with the toggle on/off, verifying close-to-tray behavior, tray menu Show/Quit, and dock icon visibility.
- Unit tests for `devicePreferences` updated and passing.
- Verified browser extension stays connected when window is in tray.

### Things reviewers should pay attention to

- The `forceQuit` flag pattern to distinguish close-vs-quit on macOS — check that `app.quit()` and `app.exit()` are used in the right places.
- The `coerce()` function in devicePreferences — this changes the write path for `loggingEnabled` too. Existing users upgrading will get their `loggingEnabled` re-written as a boolean (already the case) but now via the generic function.
- Windows/Linux tray behavior is untested — `isMac` guards are in place, but dual-platform behavior should be verified.

### Screenshots/Recordings

<img width="993" height="805" alt="image" src="https://github.com/user-attachments/assets/859823a0-9067-42e9-892e-007bb936cb62" />
<img width="124" height="101" alt="image" src="https://github.com/user-attachments/assets/723224d3-e5b8-445d-84fb-52e7355fc54e" />

### Dependencies

- No external dependencies. Depends on Electron's built-in `Tray` and `Menu` modules.