### PR TITLE
fix: chrome extension with Brave flatpack

### DIFF
--- a/electron/nativeHostWrapper.cjs
+++ b/electron/nativeHostWrapper.cjs
@@ -61,6 +61,43 @@ set ELECTRON_RUN_AS_NODE=1
   throw new Error(`Unsupported platform: ${platform}`)
 }
 
+function buildFlatpakBrowserWrapperContent({
+  electronExecPath,
+  bridgeScriptPath,
+  isPearPassFlatpak
+}) {
+  if (isPearPassFlatpak) {
+    return `#!/bin/bash
+# PearPass Native Messaging Host for Flatpak browsers
+# Flatpak browsers run native hosts inside their sandbox; re-enter the host,
+# then launch the PearPass Flatpak native host command.
+set -e
+
+if [ "\${container-}" = flatpak ]; then
+  exec flatpak-spawn --host flatpak run --command=${FLATPAK_NATIVE_HOST_COMMAND} ${FLATPAK_APP_ID} "$@"
+fi
+
+exec flatpak run --command=${FLATPAK_NATIVE_HOST_COMMAND} ${FLATPAK_APP_ID} "$@"
+`
+  }
+
+  return `#!/bin/bash
+# PearPass Native Messaging Host for Flatpak browsers
+# Flatpak browsers run native hosts inside their sandbox; re-enter the host
+# before launching the AppImage/Electron native messaging bridge.
+set -e
+
+if [ "\${container-}" = flatpak ]; then
+  exec flatpak-spawn --host env ELECTRON_RUN_AS_NODE=1 \\
+    "${electronExecPath}" \\
+    "${bridgeScriptPath}"
+fi
+
+export ELECTRON_RUN_AS_NODE=1
+exec "${electronExecPath}" "${bridgeScriptPath}"
+`
+}
+
 // Atomic so Chrome can't read a half-written wrapper while spawning the host.
 async function writeWrapperAtomic(executablePath, content, platform) {
   const tmpPath = `${executablePath}.tmp-${process.pid}`
@@ -95,6 +132,7 @@ async function refreshNativeHostWrapperIfPresent({
 }
 
 module.exports = {
+  buildFlatpakBrowserWrapperContent,
   buildWrapperContent,
   writeWrapperAtomic,
   refreshNativeHostWrapperIfPresent

--- a/electron/nativeHostWrapper.test.js
+++ b/electron/nativeHostWrapper.test.js
@@ -10,6 +10,7 @@ jest.mock('fs/promises', () => ({
 const fsp = require('fs/promises')
 
 const {
+  buildFlatpakBrowserWrapperContent,
   buildWrapperContent,
   writeWrapperAtomic,
   refreshNativeHostWrapperIfPresent
@@ -81,6 +82,37 @@ describe('buildWrapperContent', () => {
         bridgeScriptPath: BRIDGE_PATH
       })
     ).toThrow('Unsupported platform: aix')
+  })
+})
+
+describe('buildFlatpakBrowserWrapperContent', () => {
+  it('re-enters the host before launching the native bridge', () => {
+    const content = buildFlatpakBrowserWrapperContent({
+      electronExecPath: EXEC_PATH,
+      bridgeScriptPath: BRIDGE_PATH,
+      isPearPassFlatpak: false
+    })
+
+    expect(content).toContain('#!/bin/bash')
+    expect(content).toContain('flatpak-spawn --host')
+    expect(content).toContain('ELECTRON_RUN_AS_NODE=1')
+    expect(content).toContain(EXEC_PATH)
+    expect(content).toContain(BRIDGE_PATH)
+  })
+
+  it('launches the PearPass Flatpak native host command when PearPass is Flatpak', () => {
+    const content = buildFlatpakBrowserWrapperContent({
+      electronExecPath: EXEC_PATH,
+      bridgeScriptPath: BRIDGE_PATH,
+      isPearPassFlatpak: true
+    })
+
+    expect(content).toContain('flatpak-spawn --host')
+    expect(content).toContain('flatpak run')
+    expect(content).toContain('com.pears.pass')
+    expect(content).toContain('--command=pearpass-native-host')
+    expect(content).not.toContain(EXEC_PATH)
+    expect(content).not.toContain(BRIDGE_PATH)
   })
 })
 

--- a/src/utils/nativeMessagingSetup.js
+++ b/src/utils/nativeMessagingSetup.js
@@ -16,7 +16,8 @@ import nativeHostWrapper from '../../electron/nativeHostWrapper.cjs'
 
 const { isFlatpakRuntime, isSnapRuntime, getHostHome, getSnapRealHome } =
   flatpakPaths
-const { buildWrapperContent } = nativeHostWrapper
+const { buildFlatpakBrowserWrapperContent, buildWrapperContent } =
+  nativeHostWrapper
 
 const NATIVE_BRIDGE_PROCESS_IDENTIFIER = 'pearpass-lib-native-messaging-bridge'
 
@@ -113,7 +114,7 @@ export const generateNativeHostExecutable = async (
 /**
  * Returns platform-specific browser entries for native messaging manifest installation.
  * Each entry includes a browserDir for detecting whether the browser is installed.
- * @returns {{ browsers: Array<{name: string, browserDir: string|null, manifestPath: string, registryKey?: string}> }}
+ * @returns {{ browsers: Array<{name: string, browserDir: string|null, manifestPath: string, registryKey?: string, flatpakBrowserWrapperPath?: string}> }}
  */
 export const getNativeMessagingLocations = () => {
   const platform = os.platform()
@@ -354,6 +355,30 @@ export const getNativeMessagingLocations = () => {
           )
         },
         {
+          name: 'Brave (Flatpak)',
+          browserDir: null,
+          manifestPath: path.join(
+            home,
+            '.var',
+            'app',
+            'com.brave.Browser',
+            'config',
+            'BraveSoftware',
+            'Brave-Browser',
+            'NativeMessagingHosts',
+            manifestFile
+          ),
+          flatpakBrowserWrapperPath: path.join(
+            home,
+            '.var',
+            'app',
+            'com.brave.Browser',
+            'data',
+            'bin',
+            'pearpass-wrapper.sh'
+          )
+        },
+        {
           name: 'Firefox',
           isFirefox: true,
           browserDir: null,
@@ -575,7 +600,32 @@ export const setupNativeMessaging = async ({
       }
 
       try {
-        const manifest = browser.isFirefox ? firefoxManifest : chromiumManifest
+        const manifest = browser.isFirefox
+          ? firefoxManifest
+          : { ...chromiumManifest }
+
+        if (browser.flatpakBrowserWrapperPath && !useSnapDirect) {
+          const wrapperContent = buildFlatpakBrowserWrapperContent({
+            electronExecPath: execPath,
+            bridgeScriptPath: bridgePath,
+            isPearPassFlatpak: isFlatpakRuntime()
+          })
+
+          await fs.mkdir(path.dirname(browser.flatpakBrowserWrapperPath), {
+            recursive: true
+          })
+          await fs.writeFile(
+            browser.flatpakBrowserWrapperPath,
+            wrapperContent,
+            'utf8'
+          )
+          if (platform !== 'win32') {
+            await fs.chmod(browser.flatpakBrowserWrapperPath, 0o755)
+          }
+
+          manifest.path = browser.flatpakBrowserWrapperPath
+        }
+
         await fs.mkdir(path.dirname(browser.manifestPath), { recursive: true })
         await fs.writeFile(
           browser.manifestPath,

--- a/src/utils/nativeMessagingSetup.test.js
+++ b/src/utils/nativeMessagingSetup.test.js
@@ -188,7 +188,7 @@ describe('getNativeMessagingLocations', () => {
   it('should return correct browser entries for Linux including snap', () => {
     os.platform.mockReturnValue('linux')
     const { browsers } = getNativeMessagingLocations()
-    expect(browsers).toHaveLength(8)
+    expect(browsers).toHaveLength(9)
     expect(browsers[0].name).toBe('Google Chrome')
     expect(browsers[0].manifestPath).toContain('google-chrome')
     expect(browsers[0].browserDir).toBeNull()
@@ -203,15 +203,22 @@ describe('getNativeMessagingLocations', () => {
     expect(browsers[4].manifestPath).toContain('BraveSoftware/Brave-Browser')
     expect(browsers[5].name).toBe('Brave (Snap)')
     expect(browsers[5].manifestPath).toContain('snap/brave/current')
-    expect(browsers[6].name).toBe('Firefox')
+    expect(browsers[6].name).toBe('Brave (Flatpak)')
     expect(browsers[6].manifestPath).toContain(
+      '.var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser'
+    )
+    expect(browsers[6].flatpakBrowserWrapperPath).toContain(
+      '.var/app/com.brave.Browser/data/bin/pearpass-wrapper.sh'
+    )
+    expect(browsers[7].name).toBe('Firefox')
+    expect(browsers[7].manifestPath).toContain(
       '.mozilla/native-messaging-hosts'
     )
-    expect(browsers[7].name).toBe('Firefox (Snap)')
-    expect(browsers[7].manifestPath).toContain(
+    expect(browsers[8].name).toBe('Firefox (Snap)')
+    expect(browsers[8].manifestPath).toContain(
       'snap/firefox/common/.mozilla/native-messaging-hosts'
     )
-    expect(browsers[7].browserDir).toBeNull()
+    expect(browsers[8].browserDir).toBeNull()
   })
 
   it('should return correct browser entries with registry keys for Windows', () => {
@@ -242,8 +249,8 @@ describe('cleanupNativeMessaging', () => {
     os.platform.mockReturnValue('linux')
     const result = await cleanupNativeMessaging()
     expect(result.success).toBe(true)
-    expect(result.message).toContain('Removed 8 manifest file')
-    expect(fs.unlink).toHaveBeenCalledTimes(8)
+    expect(result.message).toContain('Removed 9 manifest file')
+    expect(fs.unlink).toHaveBeenCalledTimes(9)
   })
 
   it('should remove manifest files on macOS', async () => {
@@ -471,8 +478,41 @@ describe('setupNativeMessaging', () => {
       bridgePath: MOCK_BRIDGE_PATH
     })
     expect(result.success).toBe(true)
-    // Linux installs always write: 1 executable + 8 browser manifests.
-    expect(fs.writeFile).toHaveBeenCalledTimes(9)
+    // Linux installs always write: 1 executable + 9 browser manifests
+    // + the Brave Flatpak wrapper.
+    expect(fs.writeFile).toHaveBeenCalledTimes(11)
+  })
+
+  it('writes a Flatpak-aware wrapper for Brave Flatpak', async () => {
+    os.platform.mockReturnValue('linux')
+
+    const result = await setupNativeMessaging({
+      userDataPath: MOCK_USER_DATA_PATH,
+      execPath: MOCK_EXEC_PATH,
+      bridgePath: MOCK_BRIDGE_PATH
+    })
+
+    expect(result.success).toBe(true)
+
+    const flatpakWrapperWrite = fs.writeFile.mock.calls.find(([target]) =>
+      target.includes('.var/app/com.brave.Browser/data/bin/pearpass-wrapper.sh')
+    )
+    expect(flatpakWrapperWrite).toBeDefined()
+    expect(flatpakWrapperWrite[1]).toContain('flatpak-spawn --host')
+    expect(flatpakWrapperWrite[1]).toContain(MOCK_EXEC_PATH)
+    expect(flatpakWrapperWrite[1]).toContain(MOCK_BRIDGE_PATH)
+    expect(fs.chmod).toHaveBeenCalledWith(flatpakWrapperWrite[0], 0o755)
+
+    const flatpakManifestWrite = fs.writeFile.mock.calls.find(([target]) =>
+      target.includes(
+        '.var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser/NativeMessagingHosts'
+      )
+    )
+    expect(flatpakManifestWrite).toBeDefined()
+    const manifest = JSON.parse(flatpakManifestWrite[1])
+    expect(manifest.path).toContain(
+      '.var/app/com.brave.Browser/data/bin/pearpass-wrapper.sh'
+    )
   })
 
   it('under snap, skips the wrapper and points manifests at /snap/bin/<name>.native-host', async () => {
@@ -488,8 +528,8 @@ describe('setupNativeMessaging', () => {
         bridgePath: MOCK_BRIDGE_PATH
       })
       expect(result.success).toBe(true)
-      // 8 browser manifests, no wrapper executable.
-      expect(fs.writeFile).toHaveBeenCalledTimes(8)
+      // 9 browser manifests, no wrapper executable.
+      expect(fs.writeFile).toHaveBeenCalledTimes(9)
       // Every chmod is the manifest 0o644; no wrapper 0o755.
       for (const [, mode] of fs.chmod.mock.calls) {
         expect(mode).toBe(0o644)


### PR DESCRIPTION
This pull request adds support for Brave Browser installed as a Flatpak on Linux, ensuring that native messaging works correctly in sandboxed environments. It introduces a Flatpak-aware wrapper script for Brave Flatpak, updates the manifest generation logic, and thoroughly tests the new behavior.

### Changes

* Added a new entry for "Brave (Flatpak)" to the list of native messaging browser targets on Linux, including a dedicated wrapper script path (`pearpass-wrapper.sh`).
* Implemented `buildFlatpakBrowserWrapperContent` in `electron/nativeHostWrapper.cjs` to generate a Flatpak-aware wrapper script, handling both regular and PearPass Flatpak cases.
* Updated native messaging setup to write the Flatpak wrapper script, set executable permissions, and point the Brave Flatpak manifest to the wrapper.
* Modified the manifest and cleanup logic to account for the new Brave Flatpak entry. [[1]](diffhunk://#diff-111a5ccc48189911e659f4a1b7031744f75d0d93e41819fc566cef40952ce656L116-R117) [[2]](diffhunk://#diff-5ce971c0b4baf217ebf2a0e90fed5d3185d25797e8dcb85f6e81ecb4dc1bdd0dL245-R253)

### Testing Notes

* Added comprehensive tests for the new wrapper logic and updated all relevant test cases to reflect the additional Brave Flatpak target, including manifest counts and file writes. [[1]](diffhunk://#diff-592ba6b4f287079835d0e5e86a1749fc0c8b0d3ea4b889d1744f602c9003b54dR88-R118) [[2]](diffhunk://#diff-5ce971c0b4baf217ebf2a0e90fed5d3185d25797e8dcb85f6e81ecb4dc1bdd0dL191-R191) [[3]](diffhunk://#diff-5ce971c0b4baf217ebf2a0e90fed5d3185d25797e8dcb85f6e81ecb4dc1bdd0dL206-R221) [[4]](diffhunk://#diff-5ce971c0b4baf217ebf2a0e90fed5d3185d25797e8dcb85f6e81ecb4dc1bdd0dL474-R515) [[5]](diffhunk://#diff-5ce971c0b4baf217ebf2a0e90fed5d3185d25797e8dcb85f6e81ecb4dc1bdd0dL491-R532)

* Run a functional test on Linux with Brave Flatpack

These changes ensure that PearPass integrates seamlessly with Brave Flatpak, maintaining robust native messaging support across more Linux environments.