### PR TITLE
remove uses of ThemeProvider in rendering tests

### DIFF
--- a/src/components/FormModalHeaderWrapper/__snapshots__/index.test.js.snap
+++ b/src/components/FormModalHeaderWrapper/__snapshots__/index.test.js.snap
@@ -2,36 +2,31 @@
 
 exports[`FormModalHeaderWrapper renders children and buttons correctly 1`] = `
 <div>
+   
   <div
-    class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
-    data-theme="dark"
+    class="sc-bRKDuR dGUPt"
   >
-     
     <div
-      class="sc-bRKDuR dGUPt"
+      class="sc-hvigdm dEdrNg"
     >
+       
       <div
-        class="sc-hvigdm dEdrNg"
+        data-testid="test-children"
       >
-         
-        <div
-          data-testid="test-children"
-        >
-          Test Children
-        </div>
-         
+        Test Children
       </div>
+       
+    </div>
+    <div
+      class="sc-fhHczv cpmIbm"
+    >
+       
       <div
-        class="sc-fhHczv cpmIbm"
+        data-testid="test-buttons"
       >
-         
-        <div
-          data-testid="test-buttons"
-        >
-          Test Buttons
-        </div>
-         
+        Test Buttons
       </div>
+       
     </div>
   </div>
 </div>
@@ -39,26 +34,21 @@ exports[`FormModalHeaderWrapper renders children and buttons correctly 1`] = `
 
 exports[`FormModalHeaderWrapper renders with empty content 1`] = `
 <div>
+   
   <div
-    class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
-    data-theme="dark"
+    class="sc-bRKDuR dGUPt"
   >
-     
     <div
-      class="sc-bRKDuR dGUPt"
+      class="sc-hvigdm dEdrNg"
     >
-      <div
-        class="sc-hvigdm dEdrNg"
-      >
-         
-         
-      </div>
-      <div
-        class="sc-fhHczv cpmIbm"
-      >
-         
-         
-      </div>
+       
+       
+    </div>
+    <div
+      class="sc-fhHczv cpmIbm"
+    >
+       
+       
     </div>
   </div>
 </div>
@@ -66,31 +56,26 @@ exports[`FormModalHeaderWrapper renders with empty content 1`] = `
 
 exports[`FormModalHeaderWrapper renders without buttons 1`] = `
 <div>
+   
   <div
-    class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
-    data-theme="dark"
+    class="sc-bRKDuR dGUPt"
   >
-     
     <div
-      class="sc-bRKDuR dGUPt"
+      class="sc-hvigdm dEdrNg"
     >
+       
       <div
-        class="sc-hvigdm dEdrNg"
+        data-testid="test-children"
       >
-         
-        <div
-          data-testid="test-children"
-        >
-          Test Children
-        </div>
-         
+        Test Children
       </div>
-      <div
-        class="sc-fhHczv cpmIbm"
-      >
-         
-         
-      </div>
+       
+    </div>
+    <div
+      class="sc-fhHczv cpmIbm"
+    >
+       
+       
     </div>
   </div>
 </div>
@@ -98,31 +83,26 @@ exports[`FormModalHeaderWrapper renders without buttons 1`] = `
 
 exports[`FormModalHeaderWrapper renders without children 1`] = `
 <div>
+   
   <div
-    class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
-    data-theme="dark"
+    class="sc-bRKDuR dGUPt"
   >
-     
     <div
-      class="sc-bRKDuR dGUPt"
+      class="sc-hvigdm dEdrNg"
     >
+       
+       
+    </div>
+    <div
+      class="sc-fhHczv cpmIbm"
+    >
+       
       <div
-        class="sc-hvigdm dEdrNg"
+        data-testid="test-buttons"
       >
-         
-         
+        Test Buttons
       </div>
-      <div
-        class="sc-fhHczv cpmIbm"
-      >
-         
-        <div
-          data-testid="test-buttons"
-        >
-          Test Buttons
-        </div>
-         
-      </div>
+       
     </div>
   </div>
 </div>

--- a/src/components/FormModalHeaderWrapper/index.test.js
+++ b/src/components/FormModalHeaderWrapper/index.test.js
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { render, screen } from '@testing-library/react'
-import { ThemeProvider } from '@tetherto/pearpass-lib-ui-kit'
 
 import { FormModalHeaderWrapper } from './index'
 import '@testing-library/jest-dom'
@@ -12,9 +11,7 @@ describe('FormModalHeaderWrapper', () => {
 
   test('renders children and buttons correctly', () => {
     const { container } = render(
-      <ThemeProvider>
-        <FormModalHeaderWrapper children={mockChildren} buttons={mockButtons} />
-      </ThemeProvider>
+      <FormModalHeaderWrapper children={mockChildren} buttons={mockButtons} />
     )
 
     expect(screen.getByTestId('test-children')).toBeInTheDocument()
@@ -24,9 +21,7 @@ describe('FormModalHeaderWrapper', () => {
 
   test('renders without children', () => {
     const { container } = render(
-      <ThemeProvider>
-        <FormModalHeaderWrapper buttons={mockButtons} />
-      </ThemeProvider>
+      <FormModalHeaderWrapper buttons={mockButtons} />
     )
 
     expect(screen.queryByTestId('test-children')).not.toBeInTheDocument()
@@ -36,9 +31,7 @@ describe('FormModalHeaderWrapper', () => {
 
   test('renders without buttons', () => {
     const { container } = render(
-      <ThemeProvider>
-        <FormModalHeaderWrapper children={mockChildren} />
-      </ThemeProvider>
+      <FormModalHeaderWrapper children={mockChildren} />
     )
 
     expect(screen.getByTestId('test-children')).toBeInTheDocument()
@@ -47,11 +40,7 @@ describe('FormModalHeaderWrapper', () => {
   })
 
   test('renders with empty content', () => {
-    const { container } = render(
-      <ThemeProvider>
-        <FormModalHeaderWrapper />
-      </ThemeProvider>
-    )
+    const { container } = render(<FormModalHeaderWrapper />)
 
     expect(container).toMatchSnapshot()
   })

--- a/src/components/LoadingOverlay/__snapshots__/index.test.js.snap
+++ b/src/components/LoadingOverlay/__snapshots__/index.test.js.snap
@@ -3,13 +3,8 @@
 exports[`LoadingOverlay renders correctly 1`] = `
 <div>
   <div
-    class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
-    data-theme="dark"
-  >
-    <div
-      class="sc-bRKDuR hZKEqe"
-      data-testid="loading-overlay"
-    />
-  </div>
+    class="sc-bRKDuR hZKEqe"
+    data-testid="loading-overlay"
+  />
 </div>
 `;

--- a/src/components/LoadingOverlay/index.test.js
+++ b/src/components/LoadingOverlay/index.test.js
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { render } from '@testing-library/react'
-import { ThemeProvider } from '@tetherto/pearpass-lib-ui-kit'
 
 import { LoadingOverlay } from './index'
 import '@testing-library/jest-dom'
@@ -9,9 +8,7 @@ import '@testing-library/jest-dom'
 describe('LoadingOverlay', () => {
   test('renders correctly', () => {
     const { container } = render(
-      <ThemeProvider>
-        <LoadingOverlay data-testid="loading-overlay" />
-      </ThemeProvider>
+      <LoadingOverlay data-testid="loading-overlay" />
     )
 
     expect(container).toMatchSnapshot()
@@ -19,13 +16,11 @@ describe('LoadingOverlay', () => {
 
   test('passes props correctly', () => {
     const { getByTestId } = render(
-      <ThemeProvider>
-        <LoadingOverlay
-          data-testid="loading-overlay"
-          id="test-id"
-          className="test-class"
-        />
-      </ThemeProvider>
+      <LoadingOverlay
+        data-testid="loading-overlay"
+        id="test-id"
+        className="test-class"
+      />
     )
 
     const overlay = getByTestId('loading-overlay')

--- a/src/components/Overlay/__snapshots__/index.test.js.snap
+++ b/src/components/Overlay/__snapshots__/index.test.js.snap
@@ -1,10 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Overlay does not render when isRendered is false 1`] = `
-<div>
-  <div
-    class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
-    data-theme="dark"
-  />
-</div>
-`;
+exports[`Overlay does not render when isRendered is false 1`] = `<div />`;

--- a/src/components/Overlay/index.test.js
+++ b/src/components/Overlay/index.test.js
@@ -1,10 +1,15 @@
 import React from 'react'
 
 import { render, fireEvent } from '@testing-library/react'
-import { ThemeProvider } from '@tetherto/pearpass-lib-ui-kit'
 
 import { Overlay } from './index'
 import '@testing-library/jest-dom'
+
+jest.mock('@tetherto/pearpass-lib-ui-kit', () => ({
+  useTheme: () => ({
+    theme: { colors: { colorScrim: 'rgba(0, 0, 0, 0.32)' } }
+  })
+}))
 
 jest.mock('../../hooks/useAnimatedVisibility', () => ({
   useAnimatedVisibility: jest.fn().mockImplementation(({ isOpen }) => ({
@@ -22,11 +27,7 @@ describe('Overlay', () => {
   })
 
   const renderComponent = (props = {}) =>
-    render(
-      <ThemeProvider>
-        <Overlay isOpen={false} onClick={mockOnClick} {...props} />
-      </ThemeProvider>
-    )
+    render(<Overlay isOpen={false} onClick={mockOnClick} {...props} />)
 
   test('does not render when isRendered is false', () => {
     require('../../hooks/useAnimatedVisibility').useAnimatedVisibility.mockReturnValue(

--- a/src/components/RadioSelect/__snapshots__/index.test.js.snap
+++ b/src/components/RadioSelect/__snapshots__/index.test.js.snap
@@ -3,42 +3,37 @@
 exports[`RadioSelect renders the component with title and options 1`] = `
 <div>
   <div
-    class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
-    data-theme="dark"
+    data-testid="radio-select-wrapper"
   >
     <div
-      data-testid="radio-select-wrapper"
+      data-testid="title"
     >
-      <div
-        data-testid="title"
-      >
-        Select an option
-      </div>
-      <div
-        data-testid="radio-option"
-      >
-        <input
-          checked=""
-          type="radio"
-        />
-        Option 1
-      </div>
-      <div
-        data-testid="radio-option"
-      >
-        <input
-          type="radio"
-        />
-        Option 2
-      </div>
-      <div
-        data-testid="radio-option"
-      >
-        <input
-          type="radio"
-        />
-        Option 3
-      </div>
+      Select an option
+    </div>
+    <div
+      data-testid="radio-option"
+    >
+      <input
+        checked=""
+        type="radio"
+      />
+      Option 1
+    </div>
+    <div
+      data-testid="radio-option"
+    >
+      <input
+        type="radio"
+      />
+      Option 2
+    </div>
+    <div
+      data-testid="radio-option"
+    >
+      <input
+        type="radio"
+      />
+      Option 3
     </div>
   </div>
 </div>

--- a/src/components/RadioSelect/index.test.js
+++ b/src/components/RadioSelect/index.test.js
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { render, screen, fireEvent } from '@testing-library/react'
-import { ThemeProvider } from '@tetherto/pearpass-lib-ui-kit'
 
 import { RadioSelect } from './index'
 import '@testing-library/jest-dom'
@@ -33,15 +32,13 @@ describe('RadioSelect', () => {
 
   const renderComponent = (props = {}) =>
     render(
-      <ThemeProvider>
-        <RadioSelect
-          title={mockTitle}
-          options={mockOptions}
-          selectedOption="option1"
-          onChange={mockOnChange}
-          {...props}
-        />
-      </ThemeProvider>
+      <RadioSelect
+        title={mockTitle}
+        options={mockOptions}
+        selectedOption="option1"
+        onChange={mockOnChange}
+        {...props}
+      />
     )
 
   test('renders the component with title and options', () => {
@@ -91,14 +88,12 @@ describe('RadioSelect', () => {
     expect(container.querySelectorAll('input[type="radio"]')[0]).toBeChecked()
 
     rerender(
-      <ThemeProvider>
-        <RadioSelect
-          title={mockTitle}
-          options={mockOptions}
-          selectedOption="option3"
-          onChange={mockOnChange}
-        />
-      </ThemeProvider>
+      <RadioSelect
+        title={mockTitle}
+        options={mockOptions}
+        selectedOption="option3"
+        onChange={mockOnChange}
+      />
     )
 
     expect(container.querySelectorAll('input[type="radio"]')[2]).toBeChecked()

--- a/src/lib-react-components/components/InputField/__snapshots__/index.test.js.snap
+++ b/src/lib-react-components/components/InputField/__snapshots__/index.test.js.snap
@@ -2,37 +2,32 @@
 
 exports[`InputField Component matches snapshot for default variant 1`] = `
 <div
-  class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
-  data-theme="dark"
+  class="sc-bRKDuR sc-fhHczv iUcaPP fvDOQV"
 >
   <div
-    class="sc-bRKDuR sc-fhHczv iUcaPP fvDOQV"
+    class="sc-ggWZvA jlOnfN"
   >
     <div
-      class="sc-ggWZvA jlOnfN"
+      class="sc-jwTyAe hXRaZK"
     >
-      <div
-        class="sc-jwTyAe hXRaZK"
+      <span
+        class="sc-hjsuWn ebTJZm"
       >
-        <span
-          class="sc-hjsuWn ebTJZm"
-        >
-          Label
-        </span>
+        Label
+      </span>
+      <div
+        class="sc-jJLAfE gttYtk"
+      >
+        <input
+          class="sc-hwkwBN kEAjAa"
+          data-testid="input-field"
+          placeholder="Enter text"
+          type="text"
+          value="snapshot test"
+        />
         <div
-          class="sc-jJLAfE gttYtk"
-        >
-          <input
-            class="sc-hwkwBN kEAjAa"
-            data-testid="input-field"
-            placeholder="Enter text"
-            type="text"
-            value="snapshot test"
-          />
-          <div
-            class="sc-kNOymR iQIqLX"
-          />
-        </div>
+          class="sc-kNOymR iQIqLX"
+        />
       </div>
     </div>
   </div>
@@ -41,37 +36,32 @@ exports[`InputField Component matches snapshot for default variant 1`] = `
 
 exports[`InputField Component matches snapshot for outline variant 1`] = `
 <div
-  class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
-  data-theme="dark"
+  class="sc-bRKDuR sc-hvigdm iUcaPP fYHaBr"
 >
   <div
-    class="sc-bRKDuR sc-hvigdm iUcaPP fYHaBr"
+    class="sc-ggWZvA jlOnfN"
   >
     <div
-      class="sc-ggWZvA jlOnfN"
+      class="sc-jwTyAe hXRaZK"
     >
-      <div
-        class="sc-jwTyAe hXRaZK"
+      <span
+        class="sc-hjsuWn ebTJZm"
       >
-        <span
-          class="sc-hjsuWn ebTJZm"
-        >
-          Outline Label
-        </span>
+        Outline Label
+      </span>
+      <div
+        class="sc-jJLAfE gttYtk"
+      >
+        <input
+          class="sc-hwkwBN kEAjAa"
+          data-testid="input-field"
+          placeholder="Enter text"
+          type="text"
+          value="outline snapshot"
+        />
         <div
-          class="sc-jJLAfE gttYtk"
-        >
-          <input
-            class="sc-hwkwBN kEAjAa"
-            data-testid="input-field"
-            placeholder="Enter text"
-            type="text"
-            value="outline snapshot"
-          />
-          <div
-            class="sc-kNOymR iQIqLX"
-          />
-        </div>
+          class="sc-kNOymR iQIqLX"
+        />
       </div>
     </div>
   </div>

--- a/src/lib-react-components/components/InputField/index.test.js
+++ b/src/lib-react-components/components/InputField/index.test.js
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { render, fireEvent } from '@testing-library/react'
-import { ThemeProvider } from '@tetherto/pearpass-lib-ui-kit'
 import { ExpandMore as DummyIcon } from '@tetherto/pearpass-lib-ui-kit/icons'
 
 import { InputField } from './index'
@@ -10,14 +9,12 @@ import '@testing-library/jest-dom'
 describe('InputField Component', () => {
   test('renders label, placeholder, and error message', () => {
     const { getByText, getByPlaceholderText } = render(
-      <ThemeProvider>
-        <InputField
-          value="test value"
-          label="Test Label"
-          placeholder="Enter text"
-          error="Error occurred"
-        />
-      </ThemeProvider>
+      <InputField
+        value="test value"
+        label="Test Label"
+        placeholder="Enter text"
+        error="Error occurred"
+      />
     )
     expect(getByText('Test Label')).toBeInTheDocument()
     expect(getByPlaceholderText('Enter text')).toBeInTheDocument()
@@ -27,9 +24,7 @@ describe('InputField Component', () => {
   test('calls onChange when input changes if not disabled', () => {
     const handleChange = jest.fn()
     const { getByPlaceholderText } = render(
-      <ThemeProvider>
-        <InputField value="" placeholder="Enter text" onChange={handleChange} />
-      </ThemeProvider>
+      <InputField value="" placeholder="Enter text" onChange={handleChange} />
     )
     const input = getByPlaceholderText('Enter text')
     fireEvent.change(input, { target: { value: 'new value' } })
@@ -39,14 +34,12 @@ describe('InputField Component', () => {
   test('does not call onChange when disabled', () => {
     const handleChange = jest.fn()
     const { getByPlaceholderText } = render(
-      <ThemeProvider>
-        <InputField
-          value=""
-          placeholder="Enter text"
-          onChange={handleChange}
-          isDisabled={true}
-        />
-      </ThemeProvider>
+      <InputField
+        value=""
+        placeholder="Enter text"
+        onChange={handleChange}
+        isDisabled={true}
+      />
     )
     const input = getByPlaceholderText('Enter text')
     fireEvent.change(input, { target: { value: 'should not change' } })
@@ -56,13 +49,11 @@ describe('InputField Component', () => {
   test('calls onClick when outer element is clicked and focuses input', () => {
     const handleClick = jest.fn()
     const { getByPlaceholderText } = render(
-      <ThemeProvider>
-        <InputField
-          value="click test"
-          placeholder="Enter text"
-          onClick={handleClick}
-        />
-      </ThemeProvider>
+      <InputField
+        value="click test"
+        placeholder="Enter text"
+        onClick={handleClick}
+      />
     )
     const input = getByPlaceholderText('Enter text')
     const outerElement = input.closest('div')
@@ -74,13 +65,11 @@ describe('InputField Component', () => {
   test('renders overlay correctly: visible when not focused, hidden when focused', async () => {
     const overlayText = 'Overlay Content'
     const { queryByText, getByPlaceholderText } = render(
-      <ThemeProvider>
-        <InputField
-          value="overlay test"
-          placeholder="Enter text"
-          overlay={overlayText}
-        />
-      </ThemeProvider>
+      <InputField
+        value="overlay test"
+        placeholder="Enter text"
+        overlay={overlayText}
+      />
     )
     expect(queryByText(overlayText)).toBeInTheDocument()
 
@@ -91,13 +80,7 @@ describe('InputField Component', () => {
 
   test('renders icon if provided', () => {
     const { container } = render(
-      <ThemeProvider>
-        <InputField
-          value="icon test"
-          placeholder="Enter text"
-          icon={DummyIcon}
-        />
-      </ThemeProvider>
+      <InputField value="icon test" placeholder="Enter text" icon={DummyIcon} />
     )
     const icon = container.querySelector('svg')
     expect(icon).toBeInTheDocument()
@@ -106,49 +89,41 @@ describe('InputField Component', () => {
   test('renders additionalItems if provided', () => {
     const additionalItemText = 'Additional'
     const { getByText } = render(
-      <ThemeProvider>
-        <InputField
-          value="additional test"
-          placeholder="Enter text"
-          additionalItems={<div>{additionalItemText}</div>}
-        />
-      </ThemeProvider>
+      <InputField
+        value="additional test"
+        placeholder="Enter text"
+        additionalItems={<div>{additionalItemText}</div>}
+      />
     )
     expect(getByText(additionalItemText)).toBeInTheDocument()
   })
 
   test('matches snapshot for default variant', () => {
     const { container } = render(
-      <ThemeProvider>
-        <InputField
-          value="snapshot test"
-          placeholder="Enter text"
-          label="Label"
-        />
-      </ThemeProvider>
+      <InputField
+        value="snapshot test"
+        placeholder="Enter text"
+        label="Label"
+      />
     )
     expect(container.firstChild).toMatchSnapshot()
   })
 
   test('matches snapshot for outline variant', () => {
     const { container } = render(
-      <ThemeProvider>
-        <InputField
-          value="outline snapshot"
-          placeholder="Enter text"
-          label="Outline Label"
-          variant="outline"
-        />
-      </ThemeProvider>
+      <InputField
+        value="outline snapshot"
+        placeholder="Enter text"
+        label="Outline Label"
+        variant="outline"
+      />
     )
     expect(container.firstChild).toMatchSnapshot()
   })
 
   test('autoFocus prop focuses input automatically', () => {
     const { getByPlaceholderText } = render(
-      <ThemeProvider>
-        <InputField value="autofocus test" placeholder="Enter text" autoFocus />
-      </ThemeProvider>
+      <InputField value="autofocus test" placeholder="Enter text" autoFocus />
     )
     const input = getByPlaceholderText('Enter text')
     expect(document.activeElement).toBe(input)

--- a/src/lib-react-components/components/TextArea/__snapshots__/index.test.js.snap
+++ b/src/lib-react-components/components/TextArea/__snapshots__/index.test.js.snap
@@ -2,46 +2,36 @@
 
 exports[`TextArea Component matches snapshot for default variant 1`] = `
 <div
-  class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
-  data-theme="dark"
+  class="sc-fhHczv eLkUHf"
 >
   <div
-    class="sc-fhHczv eLkUHf"
+    class="sc-ggWZvA evJOyk"
   >
-    <div
-      class="sc-ggWZvA evJOyk"
+    <textarea
+      class="sc-bRKDuR cwpftx"
+      data-testid="text-area"
+      placeholder="Enter text here"
     >
-      <textarea
-        class="sc-bRKDuR cwpftx"
-        data-testid="text-area"
-        placeholder="Enter text here"
-      >
-        snapshot default
-      </textarea>
-    </div>
+      snapshot default
+    </textarea>
   </div>
 </div>
 `;
 
 exports[`TextArea Component matches snapshot for report variant 1`] = `
 <div
-  class="html-div x1ghz6dp x1717udv x1aw8gp0 xzu4p3z x78zum5 xdt5ytf x1us19tq x5yr21d xh8yej3"
-  data-theme="dark"
+  class="sc-fhHczv eLkUHf"
 >
   <div
-    class="sc-fhHczv eLkUHf"
+    class="sc-ggWZvA evJOyk"
   >
-    <div
-      class="sc-ggWZvA evJOyk"
+    <textarea
+      class="sc-hvigdm hDkxpu"
+      data-testid="text-area"
+      placeholder="Report here"
     >
-      <textarea
-        class="sc-hvigdm hDkxpu"
-        data-testid="text-area"
-        placeholder="Report here"
-      >
-        snapshot report
-      </textarea>
-    </div>
+      snapshot report
+    </textarea>
   </div>
 </div>
 `;

--- a/src/lib-react-components/components/TextArea/index.test.js
+++ b/src/lib-react-components/components/TextArea/index.test.js
@@ -1,18 +1,12 @@
 import React from 'react'
 
 import { render, fireEvent } from '@testing-library/react'
-import { ThemeProvider } from '@tetherto/pearpass-lib-ui-kit'
 
 import { TextArea } from './index'
 import '@testing-library/jest-dom'
 
 describe('TextArea Component', () => {
-  const setup = (props) =>
-    render(
-      <ThemeProvider>
-        <TextArea {...props} />
-      </ThemeProvider>
-    )
+  const setup = (props) => render(<TextArea {...props} />)
 
   test('renders with correct value and placeholder for default variant', () => {
     const { getByPlaceholderText } = setup({


### PR DESCRIPTION
### Changes
ThemeProvider styling has changed and tests that render components inside it and check against a snapshot, fail. In most places in the code, the tests render the components directly and if a component uses `useTheme()`, it is mocked in the test. This same style has been applied to failing tests and now they pass as well.

### Testing Notes
`npm test`

### Things reviewers should pay attention to
Only tests have changed and the app functionality is exactly the same.