### PR TITLE
fix: show password mismatch feedback during master password creation

### DIFF
--- a/src/pages/WelcomePage/CardCreateMasterPassword/index.tsx
+++ b/src/pages/WelcomePage/CardCreateMasterPassword/index.tsx
@@ -77,6 +77,10 @@ export const CardCreateMasterPassword = () => {
     values.password.length > 0 &&
     values.password === values.passwordConfirm
   const isFormValid = isPasswordStrong && passwordsMatch
+  const passwordsMismatch =
+    values.password.length > 0 &&
+    values.passwordConfirm.length > 0 &&
+    values.password !== values.passwordConfirm
 
   const passwordIndicator: PasswordIndicatorVariant | undefined =
     passwordStrength ? STRENGTH_MAP[passwordStrength.strengthType] : undefined
@@ -178,6 +182,7 @@ export const CardCreateMasterPassword = () => {
             value={values.passwordConfirm}
             onChangeText={handleConfirmChange}
             passwordIndicator={passwordsMatch ? 'match' : undefined}
+            error={passwordsMismatch ? t('Passwords do not match') : undefined}
             testID="confirm-password-field"
           />
 


### PR DESCRIPTION
Fixes #579.

If the passwords don't match, Continue is disabled but there's no message explaining why. The error was only set on submit, so it never showed up.

This shows “Passwords do not match” under Repeat Password once both fields have a value. The message clears when they match or either field is emptied.

Checked with six local regression tests (not included in this PR), TypeScript, and lint for the changed file. The full suite still has existing snapshot and lint failures. Couldn't verify the desktop app because the build fails on a missing `CLIPBOARD_CLEAR_TIMEOUT` dependency export.
